### PR TITLE
move chunk grid off metadata

### DIFF
--- a/src/zarr/abc/codec.py
+++ b/src/zarr/abc/codec.py
@@ -17,10 +17,10 @@ if TYPE_CHECKING:
 
     from zarr.abc.store import ByteGetter, ByteSetter, Store
     from zarr.core.array_spec import ArraySpec
-    from zarr.core.chunk_grids import ChunkGrid
     from zarr.core.dtype.wrapper import TBaseDType, TBaseScalar, ZDType
     from zarr.core.indexing import SelectorTuple
     from zarr.core.metadata import ArrayMetadata
+    from zarr.core.metadata.v3 import ChunkGridMetadata
 
 __all__ = [
     "ArrayArrayCodec",
@@ -140,7 +140,7 @@ class BaseCodec(Metadata, Generic[CodecInput, CodecOutput]):
         *,
         shape: tuple[int, ...],
         dtype: ZDType[TBaseDType, TBaseScalar],
-        chunk_grid: ChunkGrid,
+        chunk_grid: ChunkGridMetadata,
     ) -> None:
         """Validates that the codec configuration is compatible with the array metadata.
         Raises errors when the codec configuration is not compatible.
@@ -151,8 +151,8 @@ class BaseCodec(Metadata, Generic[CodecInput, CodecOutput]):
             The array shape
         dtype : np.dtype[Any]
             The array data type
-        chunk_grid : ChunkGrid
-            The array chunk grid
+        chunk_grid : ChunkGridMetadata
+            The array chunk grid metadata
         """
 
     async def _decode_single(self, chunk_data: CodecOutput, chunk_spec: ArraySpec) -> CodecInput:
@@ -357,7 +357,7 @@ class CodecPipeline:
         *,
         shape: tuple[int, ...],
         dtype: ZDType[TBaseDType, TBaseScalar],
-        chunk_grid: ChunkGrid,
+        chunk_grid: ChunkGridMetadata,
     ) -> None:
         """Validates that all codec configurations are compatible with the array metadata.
         Raises errors when a codec configuration is not compatible.
@@ -368,8 +368,8 @@ class CodecPipeline:
             The array shape
         dtype : np.dtype[Any]
             The array data type
-        chunk_grid : ChunkGrid
-            The array chunk grid
+        chunk_grid : ChunkGridMetadata
+            The array chunk grid metadata
         """
         ...
 

--- a/src/zarr/codecs/sharding.py
+++ b/src/zarr/codecs/sharding.py
@@ -52,7 +52,12 @@ from zarr.core.indexing import (
     get_indexer,
     morton_order_iter,
 )
-from zarr.core.metadata.v3 import parse_codecs
+from zarr.core.metadata.v3 import (
+    ChunkGridMetadata,
+    RectilinearChunkGrid,
+    RegularChunkGrid,
+    parse_codecs,
+)
 from zarr.registry import get_ndbuffer_class, get_pipeline_class
 from zarr.storage._utils import _normalize_byte_range_index
 
@@ -381,16 +386,13 @@ class ShardingCodec(
         *,
         shape: tuple[int, ...],
         dtype: ZDType[TBaseDType, TBaseScalar],
-        chunk_grid: ChunkGrid,
+        chunk_grid: ChunkGridMetadata,
     ) -> None:
         if len(self.chunk_shape) != len(shape):
             raise ValueError(
                 "The shard's `chunk_shape` and array's `shape` need to have the same number of dimensions."
             )
-        # Sharding works with both regular and rectilinear outer chunk grids.
-        # Each shard is self-contained — the ShardingCodec constructs an independent
-        # inner ChunkGrid per shard using the shard shape and subchunk shape.
-        if chunk_grid.is_regular:
+        if isinstance(chunk_grid, RegularChunkGrid):
             if not all(
                 s % c == 0
                 for s, c in zip(
@@ -403,15 +405,13 @@ class ShardingCodec(
                     f"The array's `chunk_shape` (got {chunk_grid.chunk_shape}) "
                     f"needs to be divisible by the shard's inner `chunk_shape` (got {self.chunk_shape})."
                 )
-        else:
+        elif isinstance(chunk_grid, RectilinearChunkGrid):
             # For rectilinear grids, every unique edge length per dimension
             # must be divisible by the corresponding inner chunk size.
-            # unique_edge_lengths is a lazy generator that short-circuits
-            # deduplication, and we short-circuit on the first failure.
-            for i, (dim, inner) in enumerate(
-                zip(chunk_grid.dimensions, self.chunk_shape, strict=False)
+            for i, (edges, inner) in enumerate(
+                zip(chunk_grid.chunk_shapes, self.chunk_shape, strict=False)
             ):
-                for edge in dim.unique_edge_lengths:
+                for edge in set(edges):
                     if edge % inner != 0:
                         raise ValueError(
                             f"Chunk edge length {edge} in dimension {i} is not "

--- a/src/zarr/codecs/transpose.py
+++ b/src/zarr/codecs/transpose.py
@@ -14,8 +14,8 @@ if TYPE_CHECKING:
     from typing import Self
 
     from zarr.core.buffer import NDBuffer
-    from zarr.core.chunk_grids import ChunkGrid
     from zarr.core.dtype.wrapper import TBaseDType, TBaseScalar, ZDType
+    from zarr.core.metadata.v3 import ChunkGridMetadata
 
 
 def parse_transpose_order(data: JSON | Iterable[int]) -> tuple[int, ...]:
@@ -51,7 +51,7 @@ class TransposeCodec(ArrayArrayCodec):
         self,
         shape: tuple[int, ...],
         dtype: ZDType[TBaseDType, TBaseScalar],
-        chunk_grid: ChunkGrid,
+        chunk_grid: ChunkGridMetadata,
     ) -> None:
         if len(self.order) != len(shape):
             raise ValueError(

--- a/src/zarr/core/array.py
+++ b/src/zarr/core/array.py
@@ -30,7 +30,7 @@ from zarr.codecs.bytes import BytesCodec
 from zarr.codecs.vlen_utf8 import VLenBytesCodec, VLenUTF8Codec
 from zarr.codecs.zstd import ZstdCodec
 from zarr.core._info import ArrayInfo
-from zarr.core.array_spec import ArrayConfig, ArrayConfigLike, parse_array_config
+from zarr.core.array_spec import ArrayConfig, ArrayConfigLike, ArraySpec, parse_array_config
 from zarr.core.attributes import Attributes
 from zarr.core.buffer import (
     BufferPrototype,
@@ -120,7 +120,12 @@ from zarr.core.metadata.v2 import (
     parse_compressor,
     parse_filters,
 )
-from zarr.core.metadata.v3 import parse_node_type_array
+from zarr.core.metadata.v3 import (
+    ChunkGridMetadata,
+    RectilinearChunkGrid,
+    RegularChunkGrid,
+    parse_node_type_array,
+)
 from zarr.core.sync import sync
 from zarr.errors import (
     ArrayNotFoundError,
@@ -306,11 +311,14 @@ class AsyncArray(Generic[T_ArrayMetadata]):
         The codec pipeline used for encoding and decoding chunks.
     config : ArrayConfig
         The runtime configuration of the array.
+    chunk_grid : ChunkGrid
+        The behavioral chunk grid bound to this array's shape.
     """
 
     metadata: T_ArrayMetadata
     store_path: StorePath
     codec_pipeline: CodecPipeline = field(init=False)
+    chunk_grid: ChunkGrid = field(init=False)
     config: ArrayConfig
 
     @overload
@@ -341,6 +349,7 @@ class AsyncArray(Generic[T_ArrayMetadata]):
         object.__setattr__(self, "metadata", metadata_parsed)
         object.__setattr__(self, "store_path", store_path)
         object.__setattr__(self, "config", config_parsed)
+        object.__setattr__(self, "chunk_grid", ChunkGrid.from_metadata(metadata_parsed))
         object.__setattr__(
             self,
             "codec_pipeline",
@@ -748,7 +757,7 @@ class AsyncArray(Generic[T_ArrayMetadata]):
         codecs: Iterable[Codec | dict[str, JSON]] | None = None,
         dimension_names: DimensionNames = None,
         attributes: dict[str, JSON] | None = None,
-        chunk_grid: ChunkGrid | None = None,
+        chunk_grid: ChunkGridMetadata | None = None,
     ) -> ArrayV3Metadata:
         """
         Create an instance of ArrayV3Metadata.
@@ -781,14 +790,15 @@ class AsyncArray(Generic[T_ArrayMetadata]):
         else:
             fill_value_parsed = fill_value
 
-        if chunk_grid is not None:
-            chunk_grid_parsed: ChunkGrid = chunk_grid
-        else:
-            chunk_grid_parsed = ChunkGrid.from_regular(shape, chunk_shape)
+        chunk_grid_meta = (
+            chunk_grid
+            if chunk_grid is not None
+            else RegularChunkGrid(chunk_shape=parse_shapelike(chunk_shape))
+        )
         return ArrayV3Metadata(
             shape=shape,
             data_type=dtype,
-            chunk_grid=chunk_grid_parsed,
+            chunk_grid=chunk_grid_meta,
             chunk_key_encoding=chunk_key_encoding_parsed,
             fill_value=fill_value_parsed,
             codecs=codecs_parsed,  # type: ignore[arg-type]
@@ -1062,6 +1072,7 @@ class AsyncArray(Generic[T_ArrayMetadata]):
         tuple[int, ...]:
             The chunk shape of the Array.
         """
+        # TODO: move sharding awareness out of metadata
         return self.metadata.chunks
 
     @property
@@ -1087,7 +1098,7 @@ class AsyncArray(Generic[T_ArrayMetadata]):
         >>> arr.chunk_sizes
         ((10, 20, 30), (50, 50))
         """
-        return self.metadata.chunk_grid.chunk_sizes
+        return self.chunk_grid.chunk_sizes
 
     @property
     def shards(self) -> tuple[int, ...] | None:
@@ -1302,7 +1313,7 @@ class AsyncArray(Generic[T_ArrayMetadata]):
             # When sharding, count inner chunks across the whole array
             chunk_shape = codecs[0].chunk_shape
             return tuple(starmap(ceildiv, zip(self.shape, chunk_shape, strict=True)))
-        return self.metadata.chunk_grid.shape
+        return self.chunk_grid.shape
 
     @property
     def _shard_grid_shape(self) -> tuple[int, ...]:
@@ -1630,6 +1641,7 @@ class AsyncArray(Generic[T_ArrayMetadata]):
             self.metadata,
             self.codec_pipeline,
             self.config,
+            self.chunk_grid,
             indexer,
             prototype=prototype,
             out=out,
@@ -1684,6 +1696,7 @@ class AsyncArray(Generic[T_ArrayMetadata]):
             self.metadata,
             self.codec_pipeline,
             self.config,
+            self.chunk_grid,
             selection,
             prototype=prototype,
         )
@@ -1701,6 +1714,7 @@ class AsyncArray(Generic[T_ArrayMetadata]):
             self.metadata,
             self.codec_pipeline,
             self.config,
+            self.chunk_grid,
             selection,
             out=out,
             fields=fields,
@@ -1720,6 +1734,7 @@ class AsyncArray(Generic[T_ArrayMetadata]):
             self.metadata,
             self.codec_pipeline,
             self.config,
+            self.chunk_grid,
             mask,
             out=out,
             fields=fields,
@@ -1739,6 +1754,7 @@ class AsyncArray(Generic[T_ArrayMetadata]):
             self.metadata,
             self.codec_pipeline,
             self.config,
+            self.chunk_grid,
             selection,
             out=out,
             fields=fields,
@@ -1764,6 +1780,7 @@ class AsyncArray(Generic[T_ArrayMetadata]):
             self.metadata,
             self.codec_pipeline,
             self.config,
+            self.chunk_grid,
             indexer,
             value,
             prototype=prototype,
@@ -1814,6 +1831,7 @@ class AsyncArray(Generic[T_ArrayMetadata]):
             self.metadata,
             self.codec_pipeline,
             self.config,
+            self.chunk_grid,
             selection,
             value,
             prototype=prototype,
@@ -1970,7 +1988,7 @@ class AsyncArray(Generic[T_ArrayMetadata]):
     def _info(
         self, count_chunks_initialized: int | None = None, count_bytes_stored: int | None = None
     ) -> Any:
-        chunk_shape = self.chunks if self.metadata.chunk_grid.is_regular else None
+        chunk_shape = self.chunks if self.chunk_grid.is_regular else None
         return ArrayInfo(
             _zarr_format=self.metadata.zarr_format,
             _data_type=self._zdtype,
@@ -2021,6 +2039,11 @@ class Array(Generic[T_ArrayMetadata]):
         An `ArrayConfig` object that defines the runtime configuration for the array.
         """
         return self.async_array.config
+
+    @property
+    def chunk_grid(self) -> ChunkGrid:
+        """The behavioral chunk grid for this array, bound to the array's shape."""
+        return self.async_array.chunk_grid
 
     @classmethod
     @deprecated("Use zarr.create_array instead.", category=ZarrDeprecationWarning)
@@ -3130,7 +3153,7 @@ class Array(Generic[T_ArrayMetadata]):
             prototype = default_buffer_prototype()
         return sync(
             self.async_array._get_selection(
-                BasicIndexer(selection, self.shape, self.metadata.chunk_grid),
+                BasicIndexer(selection, self.shape, self.chunk_grid),
                 out=out,
                 fields=fields,
                 prototype=prototype,
@@ -3237,7 +3260,7 @@ class Array(Generic[T_ArrayMetadata]):
         """
         if prototype is None:
             prototype = default_buffer_prototype()
-        indexer = BasicIndexer(selection, self.shape, self.metadata.chunk_grid)
+        indexer = BasicIndexer(selection, self.shape, self.chunk_grid)
         sync(self.async_array._set_selection(indexer, value, fields=fields, prototype=prototype))
 
     def get_orthogonal_selection(
@@ -3365,7 +3388,7 @@ class Array(Generic[T_ArrayMetadata]):
         """
         if prototype is None:
             prototype = default_buffer_prototype()
-        indexer = OrthogonalIndexer(selection, self.shape, self.metadata.chunk_grid)
+        indexer = OrthogonalIndexer(selection, self.shape, self.chunk_grid)
         return sync(
             self.async_array._get_selection(
                 indexer=indexer, out=out, fields=fields, prototype=prototype
@@ -3484,7 +3507,7 @@ class Array(Generic[T_ArrayMetadata]):
         """
         if prototype is None:
             prototype = default_buffer_prototype()
-        indexer = OrthogonalIndexer(selection, self.shape, self.metadata.chunk_grid)
+        indexer = OrthogonalIndexer(selection, self.shape, self.chunk_grid)
         return sync(
             self.async_array._set_selection(indexer, value, fields=fields, prototype=prototype)
         )
@@ -3572,7 +3595,7 @@ class Array(Generic[T_ArrayMetadata]):
 
         if prototype is None:
             prototype = default_buffer_prototype()
-        indexer = MaskIndexer(mask, self.shape, self.metadata.chunk_grid)
+        indexer = MaskIndexer(mask, self.shape, self.chunk_grid)
         return sync(
             self.async_array._get_selection(
                 indexer=indexer, out=out, fields=fields, prototype=prototype
@@ -3662,7 +3685,7 @@ class Array(Generic[T_ArrayMetadata]):
         """
         if prototype is None:
             prototype = default_buffer_prototype()
-        indexer = MaskIndexer(mask, self.shape, self.metadata.chunk_grid)
+        indexer = MaskIndexer(mask, self.shape, self.chunk_grid)
         sync(self.async_array._set_selection(indexer, value, fields=fields, prototype=prototype))
 
     def get_coordinate_selection(
@@ -3750,7 +3773,7 @@ class Array(Generic[T_ArrayMetadata]):
         """
         if prototype is None:
             prototype = default_buffer_prototype()
-        indexer = CoordinateIndexer(selection, self.shape, self.metadata.chunk_grid)
+        indexer = CoordinateIndexer(selection, self.shape, self.chunk_grid)
         out_array = sync(
             self.async_array._get_selection(
                 indexer=indexer, out=out, fields=fields, prototype=prototype
@@ -3843,7 +3866,7 @@ class Array(Generic[T_ArrayMetadata]):
         if prototype is None:
             prototype = default_buffer_prototype()
         # setup indexer
-        indexer = CoordinateIndexer(selection, self.shape, self.metadata.chunk_grid)
+        indexer = CoordinateIndexer(selection, self.shape, self.chunk_grid)
 
         # handle value - need ndarray-like flatten value
         if not is_scalar(value, self.dtype):
@@ -3965,7 +3988,7 @@ class Array(Generic[T_ArrayMetadata]):
         """
         if prototype is None:
             prototype = default_buffer_prototype()
-        indexer = BlockIndexer(selection, self.shape, self.metadata.chunk_grid)
+        indexer = BlockIndexer(selection, self.shape, self.chunk_grid)
         return sync(
             self.async_array._get_selection(
                 indexer=indexer, out=out, fields=fields, prototype=prototype
@@ -4066,7 +4089,7 @@ class Array(Generic[T_ArrayMetadata]):
         """
         if prototype is None:
             prototype = default_buffer_prototype()
-        indexer = BlockIndexer(selection, self.shape, self.metadata.chunk_grid)
+        indexer = BlockIndexer(selection, self.shape, self.chunk_grid)
         sync(self.async_array._set_selection(indexer, value, fields=fields, prototype=prototype))
 
     @property
@@ -4716,7 +4739,7 @@ async def init_array(
     # Detect rectilinear (nested list) chunks or shards, e.g. [[10, 20, 30], [25, 25]]
     from zarr.core.chunk_grids import _is_rectilinear_chunks
 
-    rectilinear_grid: ChunkGrid | None = None
+    rectilinear_meta: RectilinearChunkGrid | None = None
     rectilinear_shards = _is_rectilinear_chunks(shards)
 
     if _is_rectilinear_chunks(chunks):
@@ -4728,7 +4751,9 @@ async def init_array(
                 "Use rectilinear shards instead: "
                 "chunks=(inner_size, ...), shards=[[shard_sizes], ...]"
             )
-        rectilinear_grid = ChunkGrid.from_rectilinear(chunks, array_shape=shape_parsed)
+        rectilinear_meta = RectilinearChunkGrid(
+            chunk_shapes=tuple(tuple(dim_edges) for dim_edges in chunks)
+        )
         # Use first chunk size per dim as placeholder for _auto_partition
         chunks_flat: tuple[int, ...] | Literal["auto"] = tuple(dim_edges[0] for dim_edges in chunks)
     else:
@@ -4740,7 +4765,9 @@ async def init_array(
     if _is_rectilinear_chunks(shards):
         if zarr_format == 2:
             raise ValueError("Zarr format 2 does not support rectilinear chunk grids.")
-        rectilinear_grid = ChunkGrid.from_rectilinear(shards, array_shape=shape_parsed)
+        rectilinear_meta = RectilinearChunkGrid(
+            chunk_shapes=tuple(tuple(dim_edges) for dim_edges in shards)
+        )
         # Use first shard size per dim as placeholder for _auto_partition
         shards_for_partition = tuple(dim_edges[0] for dim_edges in shards)
 
@@ -4808,10 +4835,10 @@ async def init_array(
                 chunk_shape=chunk_shape_parsed, codecs=sub_codecs, index_location=index_location
             )
             # Use rectilinear grid for validation when shards are rectilinear
-            if rectilinear_shards and rectilinear_grid is not None:
-                validation_grid = rectilinear_grid
+            if rectilinear_shards and rectilinear_meta is not None:
+                validation_grid: ChunkGridMetadata = rectilinear_meta
             else:
-                validation_grid = ChunkGrid.from_regular(shape_parsed, shard_shape_parsed)
+                validation_grid = RegularChunkGrid(chunk_shape=shard_shape_parsed)
             sharding_codec.validate(
                 shape=chunk_shape_parsed,
                 dtype=zdtype,
@@ -4835,7 +4862,7 @@ async def init_array(
             codecs=codecs_out,
             dimension_names=dimension_names,
             attributes=attributes,
-            chunk_grid=rectilinear_grid,
+            chunk_grid=rectilinear_meta,
         )
 
     arr = AsyncArray(metadata=meta, store_path=store_path, config=config)
@@ -5063,12 +5090,12 @@ def _parse_keep_array_attr(
 ]:
     if isinstance(data, Array):
         if chunks == "keep":
-            if data.metadata.chunk_grid.is_regular:
+            if data.chunk_grid.is_regular:
                 chunks = data.chunks
             else:
                 chunks = data.chunk_sizes
         if shards == "keep":
-            shards = data.shards if data.metadata.chunk_grid.is_regular else None
+            shards = data.shards if data.chunk_grid.is_regular else None
         if zarr_format is None:
             zarr_format = data.metadata.zarr_format
         if filters == "keep":
@@ -5577,9 +5604,7 @@ def _iter_chunk_regions(
         A tuple of slice objects representing the region spanned by each shard in the selection.
     """
 
-    return array.metadata.chunk_grid.iter_chunk_regions(
-        origin=origin, selection_shape=selection_shape
-    )
+    return array.chunk_grid.iter_chunk_regions(origin=origin, selection_shape=selection_shape)
 
 
 async def _nchunks_initialized(
@@ -5652,11 +5677,32 @@ async def _nbytes_stored(
     return await store_path.store.getsize_prefix(store_path.path)
 
 
+def _get_chunk_spec(
+    metadata: ArrayMetadata,
+    chunk_grid: ChunkGrid,
+    chunk_coords: tuple[int, ...],
+    array_config: ArrayConfig,
+    prototype: BufferPrototype,
+) -> ArraySpec:
+    """Build an ArraySpec for a single chunk using the behavioral ChunkGrid."""
+    spec = chunk_grid[chunk_coords]
+    if spec is None:
+        raise IndexError(f"Chunk coordinates {chunk_coords} are out of bounds.")
+    return ArraySpec(
+        shape=spec.codec_shape,
+        dtype=metadata.dtype,
+        fill_value=metadata.fill_value,
+        config=array_config,
+        prototype=prototype,
+    )
+
+
 async def _get_selection(
     store_path: StorePath,
     metadata: ArrayMetadata,
     codec_pipeline: CodecPipeline,
     config: ArrayConfig,
+    chunk_grid: ChunkGrid,
     indexer: Indexer,
     *,
     prototype: BufferPrototype,
@@ -5733,7 +5779,7 @@ async def _get_selection(
             [
                 (
                     store_path / metadata.encode_chunk_key(chunk_coords),
-                    metadata.get_chunk_spec(chunk_coords, _config, prototype=prototype),
+                    _get_chunk_spec(metadata, chunk_grid, chunk_coords, _config, prototype),
                     chunk_selection,
                     out_selection,
                     is_complete_chunk,
@@ -5753,6 +5799,7 @@ async def _getitem(
     metadata: ArrayMetadata,
     codec_pipeline: CodecPipeline,
     config: ArrayConfig,
+    chunk_grid: ChunkGrid,
     selection: BasicSelection,
     *,
     prototype: BufferPrototype | None = None,
@@ -5770,6 +5817,8 @@ async def _getitem(
         The codec pipeline for encoding/decoding.
     config : ArrayConfig
         The array configuration.
+    chunk_grid : ChunkGrid
+        The behavioral chunk grid.
     selection : BasicSelection
         A selection object specifying the subset of data to retrieve.
     prototype : BufferPrototype, optional
@@ -5785,10 +5834,10 @@ async def _getitem(
     indexer = BasicIndexer(
         selection,
         shape=metadata.shape,
-        chunk_grid=metadata.chunk_grid,
+        chunk_grid=chunk_grid,
     )
     return await _get_selection(
-        store_path, metadata, codec_pipeline, config, indexer, prototype=prototype
+        store_path, metadata, codec_pipeline, config, chunk_grid, indexer, prototype=prototype
     )
 
 
@@ -5797,6 +5846,7 @@ async def _get_orthogonal_selection(
     metadata: ArrayMetadata,
     codec_pipeline: CodecPipeline,
     config: ArrayConfig,
+    chunk_grid: ChunkGrid,
     selection: OrthogonalSelection,
     *,
     out: NDBuffer | None = None,
@@ -5816,6 +5866,8 @@ async def _get_orthogonal_selection(
         The codec pipeline for encoding/decoding.
     config : ArrayConfig
         The array configuration.
+    chunk_grid : ChunkGrid
+        The behavioral chunk grid.
     selection : OrthogonalSelection
         The orthogonal selection specification.
     out : NDBuffer | None, optional
@@ -5832,12 +5884,13 @@ async def _get_orthogonal_selection(
     """
     if prototype is None:
         prototype = default_buffer_prototype()
-    indexer = OrthogonalIndexer(selection, metadata.shape, metadata.chunk_grid)
+    indexer = OrthogonalIndexer(selection, metadata.shape, chunk_grid)
     return await _get_selection(
         store_path,
         metadata,
         codec_pipeline,
         config,
+        chunk_grid,
         indexer=indexer,
         out=out,
         fields=fields,
@@ -5850,6 +5903,7 @@ async def _get_mask_selection(
     metadata: ArrayMetadata,
     codec_pipeline: CodecPipeline,
     config: ArrayConfig,
+    chunk_grid: ChunkGrid,
     mask: MaskSelection,
     *,
     out: NDBuffer | None = None,
@@ -5869,6 +5923,8 @@ async def _get_mask_selection(
         The codec pipeline for encoding/decoding.
     config : ArrayConfig
         The array configuration.
+    chunk_grid : ChunkGrid
+        The behavioral chunk grid.
     mask : MaskSelection
         The boolean mask specifying the selection.
     out : NDBuffer | None, optional
@@ -5885,12 +5941,13 @@ async def _get_mask_selection(
     """
     if prototype is None:
         prototype = default_buffer_prototype()
-    indexer = MaskIndexer(mask, metadata.shape, metadata.chunk_grid)
+    indexer = MaskIndexer(mask, metadata.shape, chunk_grid)
     return await _get_selection(
         store_path,
         metadata,
         codec_pipeline,
         config,
+        chunk_grid,
         indexer=indexer,
         out=out,
         fields=fields,
@@ -5903,6 +5960,7 @@ async def _get_coordinate_selection(
     metadata: ArrayMetadata,
     codec_pipeline: CodecPipeline,
     config: ArrayConfig,
+    chunk_grid: ChunkGrid,
     selection: CoordinateSelection,
     *,
     out: NDBuffer | None = None,
@@ -5922,6 +5980,8 @@ async def _get_coordinate_selection(
         The codec pipeline for encoding/decoding.
     config : ArrayConfig
         The array configuration.
+    chunk_grid : ChunkGrid
+        The behavioral chunk grid.
     selection : CoordinateSelection
         The coordinate selection specification.
     out : NDBuffer | None, optional
@@ -5938,12 +5998,13 @@ async def _get_coordinate_selection(
     """
     if prototype is None:
         prototype = default_buffer_prototype()
-    indexer = CoordinateIndexer(selection, metadata.shape, metadata.chunk_grid)
+    indexer = CoordinateIndexer(selection, metadata.shape, chunk_grid)
     out_array = await _get_selection(
         store_path,
         metadata,
         codec_pipeline,
         config,
+        chunk_grid,
         indexer=indexer,
         out=out,
         fields=fields,
@@ -5961,6 +6022,7 @@ async def _set_selection(
     metadata: ArrayMetadata,
     codec_pipeline: CodecPipeline,
     config: ArrayConfig,
+    chunk_grid: ChunkGrid,
     indexer: Indexer,
     value: npt.ArrayLike,
     *,
@@ -5980,6 +6042,8 @@ async def _set_selection(
         The codec pipeline for encoding/decoding.
     config : ArrayConfig
         The array configuration.
+    chunk_grid : ChunkGrid
+        The behavioral chunk grid.
     indexer : Indexer
         The indexer specifying the selection.
     value : npt.ArrayLike
@@ -6043,7 +6107,7 @@ async def _set_selection(
         [
             (
                 store_path / metadata.encode_chunk_key(chunk_coords),
-                metadata.get_chunk_spec(chunk_coords, _config, prototype),
+                _get_chunk_spec(metadata, chunk_grid, chunk_coords, _config, prototype),
                 chunk_selection,
                 out_selection,
                 is_complete_chunk,
@@ -6060,6 +6124,7 @@ async def _setitem(
     metadata: ArrayMetadata,
     codec_pipeline: CodecPipeline,
     config: ArrayConfig,
+    chunk_grid: ChunkGrid,
     selection: BasicSelection,
     value: npt.ArrayLike,
     prototype: BufferPrototype | None = None,
@@ -6077,6 +6142,8 @@ async def _setitem(
         The codec pipeline for encoding/decoding.
     config : ArrayConfig
         The array configuration.
+    chunk_grid : ChunkGrid
+        The behavioral chunk grid.
     selection : BasicSelection
         The selection defining the region of the array to set.
     value : npt.ArrayLike
@@ -6090,10 +6157,17 @@ async def _setitem(
     indexer = BasicIndexer(
         selection,
         shape=metadata.shape,
-        chunk_grid=metadata.chunk_grid,
+        chunk_grid=chunk_grid,
     )
     return await _set_selection(
-        store_path, metadata, codec_pipeline, config, indexer, value, prototype=prototype
+        store_path,
+        metadata,
+        codec_pipeline,
+        config,
+        chunk_grid,
+        indexer,
+        value,
+        prototype=prototype,
     )
 
 
@@ -6119,14 +6193,15 @@ async def _resize(
     assert len(new_shape) == len(array.metadata.shape)
 
     new_metadata = array.metadata.update_shape(new_shape)
+    new_chunk_grid = ChunkGrid.from_metadata(new_metadata)
 
     # ensure deletion is only run if array is shrinking as the delete_outside_chunks path is unbounded in memory
     only_growing = all(new >= old for new, old in zip(new_shape, array.metadata.shape, strict=True))
 
     if delete_outside_chunks and not only_growing:
         # Remove all chunks outside of the new shape
-        old_chunk_coords = set(array.metadata.chunk_grid.all_chunk_coords())
-        new_chunk_coords = set(new_metadata.chunk_grid.all_chunk_coords())
+        old_chunk_coords = set(array.chunk_grid.all_chunk_coords())
+        new_chunk_coords = set(new_chunk_grid.all_chunk_coords())
 
         async def _delete_key(key: str) -> None:
             await (array.store_path / key).delete()
@@ -6143,8 +6218,9 @@ async def _resize(
     # Write new metadata
     await save_metadata(array.store_path, new_metadata)
 
-    # Update metadata (in place)
+    # Update metadata and chunk_grid (in place)
     object.__setattr__(array, "metadata", new_metadata)
+    object.__setattr__(array, "chunk_grid", new_chunk_grid)
 
 
 async def _append(
@@ -6210,6 +6286,7 @@ async def _append(
         array.metadata,
         array.codec_pipeline,
         array.config,
+        array.chunk_grid,
         append_selection,
         data,
     )

--- a/src/zarr/core/chunk_grids.py
+++ b/src/zarr/core/chunk_grids.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from zarr.core.array import ShardsLike
+    from zarr.core.metadata import ArrayMetadata
 
 
 # ---------------------------------------------------------------------------
@@ -425,6 +426,26 @@ class ChunkGrid:
         object.__setattr__(
             self, "_is_regular", all(isinstance(d, FixedDimension) for d in dimensions)
         )
+
+    @classmethod
+    def from_metadata(cls, metadata: ArrayMetadata) -> ChunkGrid:
+        """Construct a behavioral ChunkGrid from array metadata.
+
+        For v2 metadata, builds from shape and chunks.
+        For v3 metadata, dispatches on the chunk grid type.
+        """
+        from zarr.core.metadata import ArrayV2Metadata
+        from zarr.core.metadata.v3 import RectilinearChunkGrid, RegularChunkGrid
+
+        if isinstance(metadata, ArrayV2Metadata):
+            return cls.from_regular(metadata.shape, metadata.chunks)
+        chunk_grid_meta = metadata.chunk_grid
+        if isinstance(chunk_grid_meta, RegularChunkGrid):
+            return cls.from_regular(metadata.shape, chunk_grid_meta.chunk_shape)
+        elif isinstance(chunk_grid_meta, RectilinearChunkGrid):
+            return cls.from_rectilinear(chunk_grid_meta.chunk_shapes, metadata.shape)
+        else:
+            raise TypeError(f"Unknown chunk grid metadata type: {type(chunk_grid_meta)}")
 
     @classmethod
     def from_regular(cls, array_shape: ShapeLike, chunk_shape: ShapeLike) -> ChunkGrid:

--- a/src/zarr/core/codec_pipeline.py
+++ b/src/zarr/core/codec_pipeline.py
@@ -27,8 +27,8 @@ if TYPE_CHECKING:
     from zarr.abc.store import ByteGetter, ByteSetter
     from zarr.core.array_spec import ArraySpec
     from zarr.core.buffer import Buffer, BufferPrototype, NDBuffer
-    from zarr.core.chunk_grids import ChunkGrid
     from zarr.core.dtype.wrapper import TBaseDType, TBaseScalar, ZDType
+    from zarr.core.metadata.v3 import ChunkGridMetadata
 
 T = TypeVar("T")
 U = TypeVar("U")
@@ -138,7 +138,7 @@ class BatchedCodecPipeline(CodecPipeline):
         *,
         shape: tuple[int, ...],
         dtype: ZDType[TBaseDType, TBaseScalar],
-        chunk_grid: ChunkGrid,
+        chunk_grid: ChunkGridMetadata,
     ) -> None:
         for codec in self:
             codec.validate(shape=shape, dtype=dtype, chunk_grid=chunk_grid)

--- a/src/zarr/core/metadata/v2.py
+++ b/src/zarr/core/metadata/v2.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Iterable, Sequence
-from functools import cached_property
 from typing import TYPE_CHECKING, Any, TypeAlias, TypedDict, cast
 
 from zarr.abc.metadata import Metadata
 from zarr.abc.numcodec import Numcodec, _is_numcodec
-from zarr.core.chunk_grids import ChunkGrid
 from zarr.core.dtype import get_data_type_from_json
 from zarr.core.dtype.common import OBJECT_CODEC_IDS, DTypeSpec_V2
 from zarr.errors import ZarrUserWarning
@@ -116,10 +114,6 @@ class ArrayV2Metadata(Metadata):
     @property
     def ndim(self) -> int:
         return len(self.shape)
-
-    @cached_property
-    def chunk_grid(self) -> ChunkGrid:
-        return ChunkGrid.from_regular(self.shape, self.chunks)
 
     @property
     def shards(self) -> tuple[int, ...] | None:

--- a/src/zarr/core/metadata/v3.py
+++ b/src/zarr/core/metadata/v3.py
@@ -1,36 +1,14 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
-from typing import TYPE_CHECKING, NotRequired, TypedDict, TypeGuard, cast
-
-from zarr.abc.metadata import Metadata
-from zarr.core.buffer.core import default_buffer_prototype
-from zarr.core.dtype import VariableLengthUTF8, ZDType, get_data_type_from_json
-from zarr.core.dtype.common import check_dtype_spec_v3
-
-if TYPE_CHECKING:
-    from typing import Self
-
-    from zarr.core.buffer import Buffer, BufferPrototype
-    from zarr.core.chunk_grids import ChunkGrid
-    from zarr.core.common import JSON
-    from zarr.core.dtype.wrapper import TBaseDType, TBaseScalar
-
-
 import json
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypedDict, TypeGuard, cast
 
 from zarr.abc.codec import ArrayArrayCodec, ArrayBytesCodec, BytesBytesCodec, Codec
+from zarr.abc.metadata import Metadata
 from zarr.core.array_spec import ArrayConfig, ArraySpec
-from zarr.core.chunk_grids import (
-    ChunkGrid,
-    ChunkGridName,
-    _infer_chunk_grid_name,
-    parse_chunk_grid,
-    serialize_chunk_grid,
-)
+from zarr.core.buffer.core import default_buffer_prototype
 from zarr.core.chunk_key_encodings import (
     ChunkKeyEncoding,
     ChunkKeyEncodingLike,
@@ -41,13 +19,22 @@ from zarr.core.common import (
     ZARR_JSON,
     DimensionNames,
     NamedConfig,
+    NamedRequiredConfig,
     parse_named_configuration,
     parse_shapelike,
 )
 from zarr.core.config import config
+from zarr.core.dtype import VariableLengthUTF8, ZDType, get_data_type_from_json
+from zarr.core.dtype.common import check_dtype_spec_v3
 from zarr.core.metadata.common import parse_attributes
 from zarr.errors import MetadataValidationError, NodeTypeValidationError, UnknownCodecError
 from zarr.registry import get_codec_class
+
+if TYPE_CHECKING:
+    from typing import Self
+
+    from zarr.core.buffer import Buffer, BufferPrototype
+    from zarr.core.dtype.wrapper import TBaseDType, TBaseScalar
 
 
 def parse_zarr_format(data: object) -> Literal[3]:
@@ -180,6 +167,233 @@ def parse_extra_fields(
         return dict(data)
 
 
+# ---------------------------------------------------------------------------
+# Chunk grid metadata types (pure DTOs — no array shape, no behavioral logic)
+# ---------------------------------------------------------------------------
+
+# JSON type for a single dimension's rectilinear spec:
+# bare int (uniform shorthand), or list of ints / [value, count] RLE pairs.
+RectilinearDimSpecJSON = int | list[int | list[int]]
+
+
+class RegularChunkGridConfig(TypedDict):
+    chunk_shape: tuple[int, ...]
+
+
+class RectilinearChunkGridConfig(TypedDict):
+    kind: Literal["inline"]
+    chunk_shapes: tuple[RectilinearDimSpecJSON, ...]
+
+
+RegularChunkGridJSON = NamedRequiredConfig[Literal["regular"], RegularChunkGridConfig]
+RectilinearChunkGridJSON = NamedRequiredConfig[Literal["rectilinear"], RectilinearChunkGridConfig]
+
+ChunkGridJSON = RegularChunkGridJSON | RectilinearChunkGridJSON
+
+
+def _parse_chunk_shape(chunk_shape: Iterable[int]) -> tuple[int, ...]:
+    """Validate and normalize a regular chunk shape. All elements must be >= 1.
+
+    The spec defines chunk indexing via modular arithmetic with the chunk
+    edge length, so zero is not a valid edge length.
+    """
+    as_tup = tuple(chunk_shape)
+    problems = [idx for idx, val in enumerate(as_tup) if val < 1]
+    if len(problems) == 1:
+        idx = problems[0]
+        raise ValueError(f"Invalid chunk shape {as_tup[idx]} at index {idx}.")
+    elif len(problems) > 1:
+        raise ValueError(
+            f"Invalid chunk shapes {[as_tup[idx] for idx in problems]} at indices {problems}."
+        )
+    return as_tup
+
+
+def _validate_rectilinear_kind(kind: str | None) -> None:
+    """The rectilinear spec requires ``kind: "inline"``."""
+    if kind is None:
+        raise ValueError(
+            "Rectilinear chunk grid configuration requires a 'kind' field. "
+            "Only 'inline' is currently supported."
+        )
+    if kind != "inline":
+        raise ValueError(
+            f"Unsupported rectilinear chunk grid kind: {kind!r}. "
+            "Only 'inline' is currently supported."
+        )
+
+
+def _expand_rle(data: Sequence[int | list[int]]) -> list[int]:
+    """Expand a mixed array of bare integers and RLE pairs.
+
+    Per the rectilinear chunk grid spec, each element can be:
+    - a bare integer (an explicit edge length)
+    - a two-element array ``[value, count]`` (run-length encoded)
+    """
+    result: list[int] = []
+    for item in data:
+        if isinstance(item, (int, float)) and not isinstance(item, bool):
+            result.append(int(item))
+        elif isinstance(item, list) and len(item) == 2:
+            size, count = int(item[0]), int(item[1])
+            result.extend([size] * count)
+        else:
+            raise ValueError(f"RLE entries must be an integer or [size, count], got {item}")
+    return result
+
+
+def _compress_rle(sizes: Sequence[int]) -> list[int | list[int]]:
+    """Compress chunk sizes to mixed RLE format per the rectilinear spec.
+
+    Runs of length > 1 are emitted as ``[value, count]`` pairs; runs of
+    length 1 are emitted as bare integers::
+
+        [10, 10, 10, 5] -> [[10, 3], 5]
+    """
+    if not sizes:
+        return []
+    result: list[int | list[int]] = []
+    current = sizes[0]
+    count = 1
+    for s in sizes[1:]:
+        if s == current:
+            count += 1
+        else:
+            result.append([current, count] if count > 1 else current)
+            current = s
+            count = 1
+    result.append([current, count] if count > 1 else current)
+    return result
+
+
+def _validate_chunk_shapes(
+    chunk_shapes: Sequence[Sequence[int]],
+) -> tuple[tuple[int, ...], ...]:
+    """Validate expanded per-dimension edge lists. All edges must be >= 1.
+
+    Unlike regular grids, rectilinear grids list explicit per-chunk edges,
+    so zero-sized edges are not meaningful.
+    """
+    result: list[tuple[int, ...]] = []
+    for dim_idx, edges in enumerate(chunk_shapes):
+        edges_tup = tuple(edges)
+        if not edges_tup:
+            raise ValueError(f"Dimension {dim_idx} has no chunk edges.")
+        bad = [i for i, e in enumerate(edges_tup) if e < 1]
+        if bad:
+            raise ValueError(
+                f"Dimension {dim_idx} has invalid edge lengths at indices {bad}: "
+                f"{[edges_tup[i] for i in bad]}"
+            )
+        result.append(edges_tup)
+    return tuple(result)
+
+
+@dataclass(frozen=True, kw_only=True)
+class RegularChunkGrid(Metadata):
+    """Metadata-only description of a regular chunk grid.
+
+    Stores just the chunk shape — no array extent, no behavioral logic.
+    This is what lives on ``ArrayV3Metadata.chunk_grid``.
+    """
+
+    chunk_shape: tuple[int, ...]
+
+    def __post_init__(self) -> None:
+        chunk_shape_parsed = _parse_chunk_shape(self.chunk_shape)
+        object.__setattr__(self, "chunk_shape", chunk_shape_parsed)
+
+    @property
+    def ndim(self) -> int:
+        return len(self.chunk_shape)
+
+    def to_dict(self) -> RegularChunkGridJSON:  # type: ignore[override]
+        return {
+            "name": "regular",
+            "configuration": {"chunk_shape": self.chunk_shape},
+        }
+
+    @classmethod
+    def from_dict(cls, data: RegularChunkGridJSON) -> Self:  # type: ignore[override]
+        _, configuration = parse_named_configuration(data, "regular")
+        return cls(chunk_shape=tuple(configuration["chunk_shape"]))
+
+
+@dataclass(frozen=True, kw_only=True)
+class RectilinearChunkGrid(Metadata):
+    """Metadata-only description of a rectilinear chunk grid.
+
+    Stores the per-dimension chunk edge lengths as expanded integer tuples
+    (no RLE). Serialization re-compresses to RLE via ``to_dict``.
+    This is what lives on ``ArrayV3Metadata.chunk_grid``.
+    """
+
+    chunk_shapes: tuple[tuple[int, ...], ...]
+
+    def __post_init__(self) -> None:
+        chunk_shapes_parsed = _validate_chunk_shapes(self.chunk_shapes)
+        object.__setattr__(self, "chunk_shapes", chunk_shapes_parsed)
+
+    @property
+    def ndim(self) -> int:
+        return len(self.chunk_shapes)
+
+    def to_dict(self) -> RectilinearChunkGridJSON:  # type: ignore[override]
+        serialized_dims: list[RectilinearDimSpecJSON] = []
+        for edges in self.chunk_shapes:
+            rle = _compress_rle(edges)
+            # Use RLE only if it's actually shorter
+            if len(rle) < len(edges):
+                serialized_dims.append(rle)
+            else:
+                serialized_dims.append(list(edges))
+        return {
+            "name": "rectilinear",
+            "configuration": {
+                "kind": "inline",
+                "chunk_shapes": tuple(serialized_dims),
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, data: RectilinearChunkGridJSON) -> Self:  # type: ignore[override]
+        _, configuration = parse_named_configuration(data, "rectilinear")
+        _validate_rectilinear_kind(configuration.get("kind"))
+        raw_shapes = configuration["chunk_shapes"]
+        expanded: list[tuple[int, ...]] = []
+        for dim_spec in raw_shapes:
+            if isinstance(dim_spec, int):
+                # Bare int shorthand — uniform edge length for this dimension.
+                # The DTO stores the single edge length; the behavioral ChunkGrid
+                # will repeat it to match the array extent when constructed.
+                if dim_spec < 1:
+                    raise ValueError(f"Integer chunk edge length must be >= 1, got {dim_spec}")
+                expanded.append((dim_spec,))
+            elif isinstance(dim_spec, list):
+                expanded.append(tuple(_expand_rle(dim_spec)))
+            else:
+                raise ValueError(f"Invalid chunk_shapes entry: {dim_spec}")
+        return cls(chunk_shapes=tuple(expanded))
+
+
+ChunkGridMetadata = RegularChunkGrid | RectilinearChunkGrid
+
+
+def parse_chunk_grid(
+    data: dict[str, JSON] | ChunkGridMetadata | NamedConfig[str, Any],
+) -> ChunkGridMetadata:
+    """Parse a chunk grid from a metadata dict or pass through an existing instance."""
+    if isinstance(data, (RegularChunkGrid, RectilinearChunkGrid)):
+        return data
+
+    name, _ = parse_named_configuration(data)
+    if name == "regular":
+        return RegularChunkGrid.from_dict(data)  # type: ignore[arg-type]
+    if name == "rectilinear":
+        return RectilinearChunkGrid.from_dict(data)  # type: ignore[arg-type]
+    raise ValueError(f"Unknown chunk grid name: {name!r}")
+
+
 class ArrayMetadataJSON_V3(TypedDict):
     """
     A typed dictionary model for zarr v3 metadata.
@@ -205,10 +419,7 @@ ARRAY_METADATA_KEYS = set(ArrayMetadataJSON_V3.__annotations__.keys())
 class ArrayV3Metadata(Metadata):
     shape: tuple[int, ...]
     data_type: ZDType[TBaseDType, TBaseScalar]
-    chunk_grid: ChunkGrid
-    chunk_grid_name: (
-        ChunkGridName  # serialization format; tracked internally for round-trip fidelity
-    )
+    chunk_grid: ChunkGridMetadata
     chunk_key_encoding: ChunkKeyEncoding
     fill_value: Any
     codecs: tuple[Codec, ...]
@@ -224,13 +435,12 @@ class ArrayV3Metadata(Metadata):
         *,
         shape: Iterable[int],
         data_type: ZDType[TBaseDType, TBaseScalar],
-        chunk_grid: dict[str, JSON] | ChunkGrid | NamedConfig[str, Any],
+        chunk_grid: dict[str, JSON] | ChunkGridMetadata | NamedConfig[str, Any],
         chunk_key_encoding: ChunkKeyEncodingLike,
         fill_value: object,
         codecs: Iterable[Codec | dict[str, JSON] | NamedConfig[str, Any] | str],
         attributes: dict[str, JSON] | None,
         dimension_names: DimensionNames,
-        chunk_grid_name: ChunkGridName | None = None,
         storage_transformers: Iterable[dict[str, JSON]] | None = None,
         extra_fields: Mapping[str, AllowedExtraField] | None = None,
     ) -> None:
@@ -239,12 +449,7 @@ class ArrayV3Metadata(Metadata):
         """
 
         shape_parsed = parse_shapelike(shape)
-        chunk_grid_parsed = parse_chunk_grid(chunk_grid, shape_parsed)
-        chunk_grid_name_parsed = (
-            chunk_grid_name
-            if chunk_grid_name is not None
-            else _infer_chunk_grid_name(chunk_grid, chunk_grid_parsed)
-        )
+        chunk_grid_parsed = parse_chunk_grid(chunk_grid)
         chunk_key_encoding_parsed = parse_chunk_key_encoding(chunk_key_encoding)
         dimension_names_parsed = parse_dimension_names(dimension_names)
         # Note: relying on a type method is numpy-specific
@@ -266,7 +471,6 @@ class ArrayV3Metadata(Metadata):
         object.__setattr__(self, "shape", shape_parsed)
         object.__setattr__(self, "data_type", data_type)
         object.__setattr__(self, "chunk_grid", chunk_grid_parsed)
-        object.__setattr__(self, "chunk_grid_name", chunk_grid_name_parsed)
         object.__setattr__(self, "chunk_key_encoding", chunk_key_encoding_parsed)
         object.__setattr__(self, "codecs", codecs_parsed)
         object.__setattr__(self, "dimension_names", dimension_names_parsed)
@@ -297,27 +501,27 @@ class ArrayV3Metadata(Metadata):
     def dtype(self) -> ZDType[TBaseDType, TBaseScalar]:
         return self.data_type
 
+    # TODO: move these behavioral properties to the Array class.
+    # They require knowledge of codecs (ShardingCodec) and don't belong on a metadata DTO.
+
     @property
     def chunks(self) -> tuple[int, ...]:
-        if self.chunk_grid.is_regular:
-            from zarr.codecs.sharding import ShardingCodec
+        if not isinstance(self.chunk_grid, RegularChunkGrid):
+            msg = (
+                "The `chunks` attribute is only defined for arrays using regular chunk grids. "
+                "This array has a rectilinear chunk grid. Use `chunk_sizes` for general access."
+            )
+            raise NotImplementedError(msg)
 
-            if len(self.codecs) == 1 and isinstance(self.codecs[0], ShardingCodec):
-                sharding_codec = self.codecs[0]
-                assert isinstance(sharding_codec, ShardingCodec)  # for mypy
-                return sharding_codec.chunk_shape
-            else:
-                return self.chunk_grid.chunk_shape
+        from zarr.codecs.sharding import ShardingCodec
 
-        msg = (
-            "The `chunks` attribute is only defined for arrays using regular chunk grids. "
-            "This array has a rectilinear chunk grid. Use `chunk_sizes` for general access."
-        )
-        raise NotImplementedError(msg)
+        if len(self.codecs) == 1 and isinstance(self.codecs[0], ShardingCodec):
+            return self.codecs[0].chunk_shape
+        return self.chunk_grid.chunk_shape
 
     @property
     def shards(self) -> tuple[int, ...] | None:
-        if not self.chunk_grid.is_regular:
+        if not isinstance(self.chunk_grid, RegularChunkGrid):
             return None
 
         from zarr.codecs.sharding import ShardingCodec
@@ -333,22 +537,6 @@ class ArrayV3Metadata(Metadata):
         if len(self.codecs) == 1 and isinstance(self.codecs[0], ShardingCodec):
             return self.codecs[0].codecs
         return self.codecs
-
-    def get_chunk_spec(
-        self, _chunk_coords: tuple[int, ...], array_config: ArrayConfig, prototype: BufferPrototype
-    ) -> ArraySpec:
-        spec = self.chunk_grid[_chunk_coords]
-        if spec is None:
-            raise ValueError(
-                f"Chunk coordinates {_chunk_coords} are out of bounds for shape {self.shape}"
-            )
-        return ArraySpec(
-            shape=spec.codec_shape,
-            dtype=self.dtype,
-            fill_value=self.fill_value,
-            config=array_config,
-            prototype=prototype,
-        )
 
     def encode_chunk_key(self, chunk_coords: tuple[int, ...]) -> str:
         return self.chunk_key_encoding.encode_chunk_key(chunk_coords)
@@ -423,13 +611,7 @@ class ArrayV3Metadata(Metadata):
         extra_fields = out_dict.pop("extra_fields")
         out_dict = out_dict | extra_fields  # type: ignore[operator]
 
-        # Serialize chunk_grid using the stored name (not the grid's own logic).
-        # This gives round-trip fidelity: a store written as "rectilinear" with
-        # uniform edges stays "rectilinear".
-        out_dict["chunk_grid"] = serialize_chunk_grid(self.chunk_grid, self.chunk_grid_name)
-
-        # chunk_grid_name is internal — not part of the Zarr metadata document
-        out_dict.pop("chunk_grid_name", None)
+        out_dict["chunk_grid"] = self.chunk_grid.to_dict()
 
         out_dict["fill_value"] = self.data_type.to_json_scalar(
             self.fill_value, zarr_format=self.zarr_format
@@ -452,8 +634,7 @@ class ArrayV3Metadata(Metadata):
         return out_dict
 
     def update_shape(self, shape: tuple[int, ...]) -> Self:
-        new_grid = self.chunk_grid.update_shape(shape)
-        return replace(self, shape=shape, chunk_grid=new_grid)
+        return replace(self, shape=shape)
 
     def update_attributes(self, attributes: dict[str, JSON]) -> Self:
         return replace(self, attributes=attributes)

--- a/src/zarr/testing/strategies.py
+++ b/src/zarr/testing/strategies.py
@@ -14,11 +14,11 @@ import zarr
 from zarr.abc.store import RangeByteRequest, Store
 from zarr.codecs.bytes import BytesCodec
 from zarr.core.array import Array
-from zarr.core.chunk_grids import ChunkGrid
 from zarr.core.chunk_key_encodings import DefaultChunkKeyEncoding
 from zarr.core.common import JSON, ZarrFormat
 from zarr.core.dtype import get_data_type_from_native_dtype
 from zarr.core.metadata import ArrayV2Metadata, ArrayV3Metadata
+from zarr.core.metadata.v3 import RegularChunkGrid
 from zarr.core.sync import sync
 from zarr.storage import MemoryStore, StoreLike
 from zarr.storage._common import _dereference_path
@@ -140,7 +140,7 @@ def array_metadata(
     # separator = draw(st.sampled_from(['/', '\\']))
     shape = draw(array_shapes())
     ndim = len(shape)
-    chunk_shape = draw(array_shapes(min_dims=ndim, max_dims=ndim))
+    chunk_shape = draw(array_shapes(min_dims=ndim, max_dims=ndim, min_side=1))
     np_dtype = draw(dtypes())
     dtype = get_data_type_from_native_dtype(np_dtype)
     fill_value = draw(npst.from_dtype(np_dtype))
@@ -160,7 +160,7 @@ def array_metadata(
         return ArrayV3Metadata(
             shape=shape,
             data_type=dtype,
-            chunk_grid=ChunkGrid.from_regular(shape, chunk_shape),
+            chunk_grid=RegularChunkGrid(chunk_shape=chunk_shape),
             fill_value=fill_value,
             attributes=draw(attributes),  # type: ignore[arg-type]
             dimension_names=draw(dimension_names(ndim=ndim)),
@@ -194,11 +194,17 @@ def chunk_shapes(draw: st.DrawFn, *, shape: tuple[int, ...]) -> tuple[int, ...]:
     # We want this strategy to shrink towards arrays with smaller number of chunks
     # 1. st.integers() shrinks towards smaller values. So we use that to generate number of chunks
     numchunks = draw(
-        st.tuples(*[st.integers(min_value=0 if size == 0 else 1, max_value=size) for size in shape])
+        st.tuples(
+            *[
+                st.integers(min_value=0 if size == 0 else 1, max_value=max(size, 1))
+                for size in shape
+            ]
+        )
     )
     # 2. and now generate the chunks tuple
+    # Chunk sizes must be >= 1 per spec; for zero-extent dimensions use 1.
     chunks = tuple(
-        size // nchunks if nchunks > 0 else 0
+        max(1, size // nchunks) if nchunks > 0 else 1
         for size, nchunks in zip(shape, numchunks, strict=True)
     )
 
@@ -260,14 +266,14 @@ def arrays(
     nparray = draw(arrays, label="array data")
     chunk_shape = draw(chunk_shapes(shape=nparray.shape), label="chunk shape")
     dim_names: None | list[str | None] = None
-    if zarr_format == 3 and all(c > 0 for c in chunk_shape):
-        shard_shape = draw(
-            st.none() | shard_shapes(shape=nparray.shape, chunk_shape=chunk_shape),
-            label="shard shape",
-        )
+    shard_shape = None
+    if zarr_format == 3:
         dim_names = draw(dimension_names(ndim=nparray.ndim), label="dimension names")
-    else:
-        shard_shape = None
+        if all(s > 0 for s in nparray.shape) and all(c > 0 for c in chunk_shape):
+            shard_shape = draw(
+                st.none() | shard_shapes(shape=nparray.shape, chunk_shape=chunk_shape),
+                label="shard shape",
+            )
     # test that None works too.
     fill_value = draw(st.one_of([st.none(), npst.from_dtype(nparray.dtype)]))
     # compressor = draw(compressors)

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -796,13 +796,13 @@ def test_resize_growing_skips_chunk_enumeration(
     )
     z[:] = np.ones((10, 10), dtype="i4")
 
-    grid_cls = type(z.metadata.chunk_grid)
+    grid_cls = type(z.chunk_grid)
 
     # growth only - ensure no chunk coords are enumerated
     with mock.patch.object(
         grid_cls,
         "all_chunk_coords",
-        wraps=z.metadata.chunk_grid.all_chunk_coords,
+        wraps=z.chunk_grid.all_chunk_coords,
     ) as mock_coords:
         z.resize((20, 20))
         mock_coords.assert_not_called()
@@ -815,7 +815,7 @@ def test_resize_growing_skips_chunk_enumeration(
     with mock.patch.object(
         grid_cls,
         "all_chunk_coords",
-        wraps=z.metadata.chunk_grid.all_chunk_coords,
+        wraps=z.chunk_grid.all_chunk_coords,
     ) as mock_coords:
         z.resize((5, 5))
         assert mock_coords.call_count > 0
@@ -838,7 +838,7 @@ def test_resize_growing_skips_chunk_enumeration(
     with mock.patch.object(
         grid_cls,
         "all_chunk_coords",
-        wraps=z2.metadata.chunk_grid.all_chunk_coords,
+        wraps=z2.chunk_grid.all_chunk_coords,
     ) as mock_coords:
         z2.resize((20, 5))
         assert mock_coords.call_count > 0
@@ -1576,7 +1576,7 @@ class TestCreateArray:
         elif impl == "async":
             arr = await create_array(store, name=name, data=data, zarr_format=3)
             stored = await arr._get_selection(
-                BasicIndexer(..., shape=arr.shape, chunk_grid=arr.metadata.chunk_grid),
+                BasicIndexer(..., shape=arr.shape, chunk_grid=arr.chunk_grid),
                 prototype=default_buffer_prototype(),
             )
         else:

--- a/tests/test_codecs/test_sharding.py
+++ b/tests/test_codecs/test_sharding.py
@@ -1,5 +1,4 @@
 import pickle
-import re
 from typing import Any
 
 import numpy as np
@@ -489,9 +488,7 @@ def test_invalid_metadata(store: Store) -> None:
 def test_invalid_shard_shape() -> None:
     with pytest.raises(
         ValueError,
-        match=re.escape(
-            "The array's `chunk_shape` (got (16, 16)) needs to be divisible by the shard's inner `chunk_shape` (got (9,))."
-        ),
+        match="needs to be divisible by the shard's inner",
     ):
         zarr.create_array(
             {},

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -1219,8 +1219,8 @@ def test_get_block_selection_1d(store: StorePath) -> None:
         _test_get_block_selection(a, z, selection, expected_idx)
 
     bad_selections = block_selections_1d_bad + [
-        z.metadata.chunk_grid.get_nchunks() + 1,  # out of bounds
-        -(z.metadata.chunk_grid.get_nchunks() + 1),  # out of bounds
+        z.chunk_grid.get_nchunks() + 1,  # out of bounds
+        -(z.chunk_grid.get_nchunks() + 1),  # out of bounds
     ]
 
     for selection_bad in bad_selections:
@@ -1933,9 +1933,11 @@ def test_indexing_with_zarr_array(store: StorePath) -> None:
 
 
 @pytest.mark.parametrize("store", ["local", "memory"], indirect=["store"])
-@pytest.mark.parametrize("shape", [(0, 2, 3), (0), (3, 0)])
+@pytest.mark.parametrize("shape", [(0, 2, 3), (0,), (3, 0)])
 def test_zero_sized_chunks(store: StorePath, shape: list[int]) -> None:
-    z = zarr.create_array(store=store, shape=shape, chunks=shape, zarr_format=3, dtype="f8")
+    # Chunk sizes must be >= 1 per spec; use 1 for zero-extent dimensions.
+    chunks = tuple(max(1, s) for s in shape)
+    z = zarr.create_array(store=store, shape=shape, chunks=chunks, zarr_format=3, dtype="f8")
     z[...] = 42
     assert_array_equal(z[...], np.zeros(shape, dtype="f8"))
 


### PR DESCRIPTION
This PR moves the chunk grid object off the array metadata objects and on to the `AsyncArray`. `ArrayV3Metadata.chunk_grid` is now a plain dataclass that serves to model the contents of array metadata.

The logic for this change is that we want to keep the array metadata classes scoped to modelling the contents of array metadata. Giving these classes methods for array indexing complicates or even interferes with roles as models for array metadata documents.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.md`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
