### PR TITLE
refactor: allow regular-style chunk grid declaration for rectilinear chunk grid

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "WebFetch(domain:api.github.com)",
-      "Read(//home/d-v-b/dev/zarr-python/**)"
-    ]
-  }
-}

--- a/src/zarr/codecs/sharding.py
+++ b/src/zarr/codecs/sharding.py
@@ -409,10 +409,11 @@ class ShardingCodec(
         elif isinstance(chunk_grid, RectilinearChunkGrid):
             # For rectilinear grids, every unique edge length per dimension
             # must be divisible by the corresponding inner chunk size.
-            for i, (edges, inner) in enumerate(
+            for i, (dim_spec, inner) in enumerate(
                 zip(chunk_grid.chunk_shapes, self.chunk_shape, strict=False)
             ):
-                for edge in set(edges):
+                unique_edges = {dim_spec} if isinstance(dim_spec, int) else set(dim_spec)
+                for edge in unique_edges:
                     if edge % inner != 0:
                         raise ValueError(
                             f"Chunk edge length {edge} in dimension {i} is not "
@@ -437,7 +438,7 @@ class ShardingCodec(
         indexer = BasicIndexer(
             tuple(slice(0, s) for s in shard_shape),
             shape=shard_shape,
-            chunk_grid=ChunkGrid.from_regular(shard_shape, chunk_shape),
+            chunk_grid=ChunkGrid.from_sizes(shard_shape, chunk_shape),
         )
 
         # setup output array
@@ -483,7 +484,7 @@ class ShardingCodec(
         indexer = get_indexer(
             selection,
             shape=shard_shape,
-            chunk_grid=ChunkGrid.from_regular(shard_shape, chunk_shape),
+            chunk_grid=ChunkGrid.from_sizes(shard_shape, chunk_shape),
         )
 
         # setup output array
@@ -558,7 +559,7 @@ class ShardingCodec(
             BasicIndexer(
                 tuple(slice(0, s) for s in shard_shape),
                 shape=shard_shape,
-                chunk_grid=ChunkGrid.from_regular(shard_shape, chunk_shape),
+                chunk_grid=ChunkGrid.from_sizes(shard_shape, chunk_shape),
             )
         )
 
@@ -600,7 +601,7 @@ class ShardingCodec(
             get_indexer(
                 selection,
                 shape=shard_shape,
-                chunk_grid=ChunkGrid.from_regular(shard_shape, chunk_shape),
+                chunk_grid=ChunkGrid.from_sizes(shard_shape, chunk_shape),
             )
         )
 

--- a/src/zarr/core/chunk_grids.py
+++ b/src/zarr/core/chunk_grids.py
@@ -17,15 +17,10 @@ import numpy.typing as npt
 import zarr
 from zarr.core.common import (
     JSON,
-    NamedConfig,
     ShapeLike,
     ceildiv,
-    compress_rle,
     expand_rle,
-    parse_named_configuration,
     parse_shapelike,
-    validate_rectilinear_edges,
-    validate_rectilinear_kind,
 )
 from zarr.errors import ZarrUserWarning
 
@@ -277,31 +272,6 @@ class ChunkSpec:
 
 # A single dimension's rectilinear chunk spec: bare int (uniform shorthand),
 # list of ints (explicit edges), or mixed RLE (e.g. [[10, 3], 5]).
-RectilinearDimSpec = int | list[int | list[int]]
-
-# The serialization format name for a chunk grid.
-ChunkGridName = Literal["regular", "rectilinear"]
-
-
-def _serialize_fixed_dim(dim: FixedDimension) -> RectilinearDimSpec:
-    """Compact rectilinear representation for a fixed-size dimension.
-
-    Per the rectilinear spec, a bare integer is repeated until the sum
-    >= extent.  This preserves the full codec buffer size for boundary
-    chunks, matching the regular grid spec ("chunks at the border always
-    have the full chunk size").
-    """
-    return dim.size
-
-
-def _serialize_varying_dim(dim: VaryingDimension) -> RectilinearDimSpec:
-    """RLE-compressed rectilinear representation for a varying dimension."""
-    edges = list(dim.edges)
-    rle = compress_rle(edges)
-    if len(rle) < len(edges):
-        return rle
-    # mypy: list[int] is invariant, so it won't widen to list[int | list[int]]
-    return cast("RectilinearDimSpec", edges)
 
 
 def _decode_dim_spec(dim_spec: JSON, array_extent: int | None = None) -> list[int]:
@@ -391,92 +361,58 @@ class ChunkGrid:
         from zarr.core.metadata.v3 import RectilinearChunkGrid, RegularChunkGrid
 
         if isinstance(metadata, ArrayV2Metadata):
-            return cls.from_regular(metadata.shape, metadata.chunks)
+            return cls.from_sizes(metadata.shape, tuple(metadata.chunks))
         chunk_grid_meta = metadata.chunk_grid
         if isinstance(chunk_grid_meta, RegularChunkGrid):
-            return cls.from_regular(metadata.shape, chunk_grid_meta.chunk_shape)
+            return cls.from_sizes(metadata.shape, tuple(chunk_grid_meta.chunk_shape))
         elif isinstance(chunk_grid_meta, RectilinearChunkGrid):
-            return cls.from_rectilinear(chunk_grid_meta.chunk_shapes, metadata.shape)
+            return cls.from_sizes(metadata.shape, chunk_grid_meta.chunk_shapes)
         else:
             raise TypeError(f"Unknown chunk grid metadata type: {type(chunk_grid_meta)}")
 
     @classmethod
-    def from_regular(cls, array_shape: ShapeLike, chunk_shape: ShapeLike) -> ChunkGrid:
-        """Create a ChunkGrid where all dimensions are fixed (regular)."""
-        shape_parsed = parse_shapelike(array_shape)
-        chunks_parsed = parse_shapelike(chunk_shape)
-        if len(shape_parsed) != len(chunks_parsed):
-            raise ValueError(
-                f"array_shape and chunk_shape must have same ndim, "
-                f"got {len(shape_parsed)} vs {len(chunks_parsed)}"
-            )
-        dims = tuple(
-            FixedDimension(size=c, extent=s)
-            for s, c in zip(shape_parsed, chunks_parsed, strict=True)
-        )
-        return cls(dimensions=dims)
-
-    @classmethod
-    def from_rectilinear(
+    def from_sizes(
         cls,
-        chunk_shapes: Sequence[Sequence[int]],
         array_shape: ShapeLike,
+        chunk_sizes: Sequence[int | Sequence[int]],
     ) -> ChunkGrid:
-        """Create a ChunkGrid with per-dimension edge lists.
-
-        Each element of chunk_shapes is a sequence of chunk sizes for that dimension.
-        If all sizes in a dimension are identical *and* the extent equals
-        ``sum(edges)``, the dimension is stored as ``FixedDimension``.
-        Otherwise it is stored as ``VaryingDimension``, preserving the
-        explicit edge count (important when the last chunk extends past
-        the array boundary).
+        """Create a ChunkGrid from per-dimension chunk size specifications.
 
         Parameters
         ----------
-        chunk_shapes
-            Per-dimension sequences of chunk edge lengths.
         array_shape
-            The array shape to bind as the extent per dimension. The last
-            chunk along each dimension may extend past the array boundary
-            (the edge is the codec buffer size; ``data_size`` clips to the
-            extent).
+            The array shape (one extent per dimension).
+        chunk_sizes
+            Per-dimension chunk sizes. Each element is either:
 
-        Raises
-        ------
-        ValueError
-            If the ``array.rectilinear_chunks`` config option is not enabled.
+            - An ``int`` — regular (fixed) chunk size for that dimension.
+            - A ``Sequence[int]`` — explicit per-chunk edge lengths. If all
+              edges are identical and cover the extent, the dimension is
+              stored as ``FixedDimension``; otherwise as ``VaryingDimension``.
         """
-        from zarr.core.config import config
-
-        if not config.get("array.rectilinear_chunks"):
-            raise ValueError(
-                "Rectilinear chunk grids are experimental and disabled by default. "
-                "Enable them with: zarr.config.set({'array.rectilinear_chunks': True}) "
-                "or set the environment variable ZARR_ARRAY__RECTILINEAR_CHUNKS=True"
-            )
         extents = parse_shapelike(array_shape)
-        if len(extents) != len(chunk_shapes):
+        if len(extents) != len(chunk_sizes):
             raise ValueError(
-                f"array_shape has {len(extents)} dimensions but chunk_shapes "
-                f"has {len(chunk_shapes)} dimensions"
+                f"array_shape has {len(extents)} dimensions but chunk_sizes "
+                f"has {len(chunk_sizes)} dimensions"
             )
         dims: list[DimensionGrid] = []
-        for edges, extent in zip(chunk_shapes, extents, strict=True):
-            edges_list = list(edges)
-            if not edges_list:
-                raise ValueError("Each dimension must have at least one chunk")
-            edge_sum = sum(edges_list)
-            # Collapse to FixedDimension when edges are uniform AND either
-            # extent == edge_sum (exact fit) or the number of edges matches
-            # ceildiv(extent, edge) (regular grid with boundary overflow).
-            if (
-                edges_list[0] > 0
-                and all(e == edges_list[0] for e in edges_list)
-                and (extent == edge_sum or len(edges_list) == ceildiv(extent, edges_list[0]))
-            ):
-                dims.append(FixedDimension(size=edges_list[0], extent=extent))
+        for dim_spec, extent in zip(chunk_sizes, extents, strict=True):
+            if isinstance(dim_spec, int):
+                dims.append(FixedDimension(size=dim_spec, extent=extent))
             else:
-                dims.append(VaryingDimension(edges_list, extent=extent))
+                edges_list = list(dim_spec)
+                if not edges_list:
+                    raise ValueError("Each dimension must have at least one chunk")
+                edge_sum = sum(edges_list)
+                if (
+                    edges_list[0] > 0
+                    and all(e == edges_list[0] for e in edges_list)
+                    and (extent == edge_sum or len(edges_list) == ceildiv(extent, edges_list[0]))
+                ):
+                    dims.append(FixedDimension(size=edges_list[0], extent=extent))
+                else:
+                    dims.append(VaryingDimension(edges_list, extent=extent))
         return cls(dimensions=tuple(dims))
 
     # -- Properties --
@@ -631,118 +567,6 @@ class ChunkGrid:
             for dim, new_extent in zip(self.dimensions, new_shape, strict=True)
         )
         return ChunkGrid(dimensions=dims)
-
-    # ChunkGrid does not serialize itself. The format choice ("regular" vs
-    # "rectilinear") belongs to the metadata layer. Use serialize_chunk_grid()
-    # for output and parse_chunk_grid() for input.
-
-
-def parse_chunk_grid(
-    data: dict[str, JSON] | ChunkGrid | NamedConfig[str, Any],
-    array_shape: tuple[int, ...],
-) -> ChunkGrid:
-    """Create a ChunkGrid from a metadata dict or existing grid, binding array shape.
-
-    This is the primary entry point for constructing a ChunkGrid from serialized
-    metadata. It always produces a grid with correct extent values.
-
-    Both ``"regular"`` and ``"rectilinear"`` grid names are supported. Rectilinear
-    grids are experimental and require the ``array.rectilinear_chunks`` config
-    option to be enabled; a ``ValueError`` is raised otherwise.
-    """
-    if isinstance(data, ChunkGrid):
-        # Re-bind extent if array_shape differs from what's stored
-        dims = tuple(
-            dim.with_extent(extent)
-            for dim, extent in zip(data.dimensions, array_shape, strict=True)
-        )
-        return ChunkGrid(dimensions=dims)
-
-    name_parsed, configuration_parsed = parse_named_configuration(data)
-
-    if name_parsed == "regular":
-        chunk_shape_raw = configuration_parsed.get("chunk_shape")
-        if chunk_shape_raw is None:
-            raise ValueError("Regular chunk grid requires 'chunk_shape' configuration")
-        if not isinstance(chunk_shape_raw, Sequence):
-            raise TypeError(f"chunk_shape must be a sequence, got {type(chunk_shape_raw)}")
-        return ChunkGrid.from_regular(array_shape, cast("Sequence[int]", chunk_shape_raw))
-
-    if name_parsed == "rectilinear":
-        validate_rectilinear_kind(cast("str | None", configuration_parsed.get("kind")))
-        chunk_shapes_raw = configuration_parsed.get("chunk_shapes")
-        if chunk_shapes_raw is None:
-            raise ValueError("Rectilinear chunk grid requires 'chunk_shapes' configuration")
-        if not isinstance(chunk_shapes_raw, Sequence):
-            raise TypeError(f"chunk_shapes must be a sequence, got {type(chunk_shapes_raw)}")
-        if len(chunk_shapes_raw) != len(array_shape):
-            raise ValueError(
-                f"chunk_shapes has {len(chunk_shapes_raw)} dimensions but array shape "
-                f"has {len(array_shape)} dimensions"
-            )
-        decoded: list[list[int]] = []
-        for dim_spec, extent in zip(chunk_shapes_raw, array_shape, strict=True):
-            decoded.append(_decode_dim_spec(dim_spec, array_extent=extent))
-        validate_rectilinear_edges(decoded, array_shape)
-        return ChunkGrid.from_rectilinear(decoded, array_shape=array_shape)
-
-    raise ValueError(f"Unknown chunk grid name: {name_parsed!r}")
-
-
-def serialize_chunk_grid(grid: ChunkGrid, name: ChunkGridName) -> dict[str, JSON]:
-    """Serialize a ChunkGrid to a metadata dict using the given format name.
-
-    The format choice ("regular" vs "rectilinear") belongs to the metadata layer,
-    not the grid itself. This function is called by ArrayV3Metadata.to_dict().
-    """
-    if name == "regular":
-        if not grid.is_regular:
-            raise ValueError(
-                "Cannot serialize a non-regular chunk grid as 'regular'. Use 'rectilinear' instead."
-            )
-        # The regular grid spec encodes only chunk_shape, not per-axis edges,
-        # so zero-extent dimensions are valid (they simply produce zero chunks).
-        return {
-            "name": "regular",
-            "configuration": {"chunk_shape": tuple(grid.chunk_shape)},
-        }
-
-    if name == "rectilinear":
-        # Zero-extent dimensions cannot be represented as rectilinear because
-        # the spec requires at least one positive-integer edge length per axis.
-        # This is intentionally asymmetric with the regular grid, which encodes
-        # only chunk_shape (no per-axis edges) and thus handles zero-extent
-        # arrays without issue.
-        if any(d.extent == 0 for d in grid.dimensions):
-            raise ValueError(
-                "Cannot serialize a zero-extent grid as 'rectilinear': "
-                "the spec requires all edge lengths to be positive integers."
-            )
-        chunk_shapes: list[RectilinearDimSpec] = []
-        for dim in grid.dimensions:
-            if isinstance(dim, FixedDimension):
-                chunk_shapes.append(_serialize_fixed_dim(dim))
-            elif isinstance(dim, VaryingDimension):
-                chunk_shapes.append(_serialize_varying_dim(dim))
-            else:
-                raise TypeError(f"Unexpected dimension type: {type(dim)}")
-        return {
-            "name": "rectilinear",
-            "configuration": {"kind": "inline", "chunk_shapes": chunk_shapes},
-        }
-
-    raise ValueError(f"Unknown chunk grid name for serialization: {name!r}")
-
-
-def _infer_chunk_grid_name(
-    data: dict[str, JSON] | ChunkGrid | NamedConfig[str, Any],
-    grid: ChunkGrid,
-) -> ChunkGridName:
-    """Extract or infer the chunk grid serialization name from the input."""
-    if isinstance(data, dict):
-        name, _ = parse_named_configuration(data)
-        return cast("ChunkGridName", name)
-    return "regular" if grid.is_regular else "rectilinear"
 
 
 def _guess_chunks(
@@ -982,18 +806,18 @@ class RegularChunkGrid(metaclass=_RegularChunkGridMeta):
     """Deprecated compatibility shim.
 
     .. deprecated:: 3.1
-        Use ``ChunkGrid.from_regular(array_shape, chunk_shape)`` instead.
+        Use ``ChunkGrid.from_sizes(array_shape, chunk_sizes)`` instead.
         Use ``grid.is_regular`` instead of ``isinstance(grid, RegularChunkGrid)``.
     """
 
     def __new__(cls, *, chunk_shape: ShapeLike) -> ChunkGrid:  # type: ignore[misc]
         warnings.warn(
             "RegularChunkGrid is deprecated. "
-            "Use ChunkGrid.from_regular(array_shape, chunk_shape) instead.",
+            "Use ChunkGrid.from_sizes(array_shape, chunk_sizes) instead.",
             DeprecationWarning,
             stacklevel=2,
         )
         # Without array_shape we cannot bind extents, so use chunk_shape as extent.
         # This matches the old behavior where RegularChunkGrid was shape-unaware.
         parsed = parse_shapelike(chunk_shape)
-        return ChunkGrid.from_regular(array_shape=parsed, chunk_shape=parsed)
+        return ChunkGrid.from_sizes(array_shape=parsed, chunk_sizes=tuple(parsed))

--- a/src/zarr/core/common.py
+++ b/src/zarr/core/common.py
@@ -311,15 +311,17 @@ def validate_rectilinear_kind(kind: str | None) -> None:
 
 
 def validate_rectilinear_edges(
-    chunk_shapes: Sequence[Sequence[int]], array_shape: Sequence[int]
+    chunk_shapes: Sequence[int | Sequence[int]], array_shape: Sequence[int]
 ) -> None:
     """Validate that rectilinear chunk edges cover the array extent per dimension.
 
-    Raises ValueError if any dimension's edge sum is less than the corresponding
-    array extent.
+    Bare-int dimensions (regular step) always cover any extent, so they are
+    skipped. Explicit edge lists must sum to at least the array extent.
     """
-    for i, (edges, extent) in enumerate(zip(chunk_shapes, array_shape, strict=True)):
-        edge_sum = sum(edges)
+    for i, (dim_spec, extent) in enumerate(zip(chunk_shapes, array_shape, strict=True)):
+        if isinstance(dim_spec, int):
+            continue
+        edge_sum = sum(dim_spec)
         if edge_sum < extent:
             raise ValueError(
                 f"Rectilinear chunk edges for dimension {i} sum to {edge_sum} "

--- a/src/zarr/core/metadata/v2.py
+++ b/src/zarr/core/metadata/v2.py
@@ -131,7 +131,7 @@ class ArrayV2Metadata(Metadata):
             DeprecationWarning,
             stacklevel=2,
         )
-        return ChunkGrid.from_regular(self.shape, self.chunks)
+        return ChunkGrid.from_sizes(self.shape, tuple(self.chunks))
 
     @property
     def shards(self) -> tuple[int, ...] | None:

--- a/src/zarr/core/metadata/v3.py
+++ b/src/zarr/core/metadata/v3.py
@@ -192,43 +192,43 @@ ChunkGridJSON = RegularChunkGridJSON | RectilinearChunkGridJSON
 
 
 def _parse_chunk_shape(chunk_shape: Iterable[int]) -> tuple[int, ...]:
-    """Validate and normalize a regular chunk shape. All elements must be >= 1.
+    """Validate and normalize a regular chunk shape.
 
-    The spec defines chunk indexing via modular arithmetic with the chunk
-    edge length, so zero is not a valid edge length.
+    Delegates to ``_validate_chunk_shapes`` — a regular chunk shape is just
+    a sequence of bare ints (one per dimension), each of which must be >= 1.
     """
-    as_tup = tuple(chunk_shape)
-    problems = [idx for idx, val in enumerate(as_tup) if val < 1]
-    if len(problems) == 1:
-        idx = problems[0]
-        raise ValueError(f"Invalid chunk shape {as_tup[idx]} at index {idx}.")
-    elif len(problems) > 1:
-        raise ValueError(
-            f"Invalid chunk shapes {[as_tup[idx] for idx in problems]} at indices {problems}."
-        )
-    return as_tup
+    result = _validate_chunk_shapes(tuple(chunk_shape))
+    # Regular grids only have bare ints — cast is safe after validation
+    return cast(tuple[int, ...], result)
 
 
 def _validate_chunk_shapes(
-    chunk_shapes: Sequence[Sequence[int]],
-) -> tuple[tuple[int, ...], ...]:
-    """Validate expanded per-dimension edge lists. All edges must be >= 1.
+    chunk_shapes: Sequence[int | Sequence[int]],
+) -> tuple[int | tuple[int, ...], ...]:
+    """Validate per-dimension chunk specifications.
 
-    Unlike regular grids, rectilinear grids list explicit per-chunk edges,
-    so zero-sized edges are not meaningful.
+    Each element is either a bare ``int`` (regular step size, must be >= 1)
+    or a sequence of explicit edge lengths (all must be >= 1, non-empty).
     """
-    result: list[tuple[int, ...]] = []
-    for dim_idx, edges in enumerate(chunk_shapes):
-        edges_tup = tuple(edges)
-        if not edges_tup:
-            raise ValueError(f"Dimension {dim_idx} has no chunk edges.")
-        bad = [i for i, e in enumerate(edges_tup) if e < 1]
-        if bad:
-            raise ValueError(
-                f"Dimension {dim_idx} has invalid edge lengths at indices {bad}: "
-                f"{[edges_tup[i] for i in bad]}"
-            )
-        result.append(edges_tup)
+    result: list[int | tuple[int, ...]] = []
+    for dim_idx, dim_spec in enumerate(chunk_shapes):
+        if isinstance(dim_spec, int):
+            if dim_spec < 1:
+                raise ValueError(
+                    f"Dimension {dim_idx}: integer chunk edge length must be >= 1, got {dim_spec}"
+                )
+            result.append(dim_spec)
+        else:
+            edges = tuple(dim_spec)
+            if not edges:
+                raise ValueError(f"Dimension {dim_idx} has no chunk edges.")
+            bad = [i for i, e in enumerate(edges) if e < 1]
+            if bad:
+                raise ValueError(
+                    f"Dimension {dim_idx} has invalid edge lengths at indices {bad}: "
+                    f"{[edges[i] for i in bad]}"
+                )
+            result.append(edges)
     return tuple(result)
 
 
@@ -267,16 +267,30 @@ class RegularChunkGrid(Metadata):
 class RectilinearChunkGrid(Metadata):
     """Metadata-only description of a rectilinear chunk grid.
 
-    Stores the per-dimension chunk edge lengths as expanded integer tuples
-    (no RLE). Serialization re-compresses to RLE via ``to_dict``.
-    This is what lives on ``ArrayV3Metadata.chunk_grid``.
+    Each element of ``chunk_shapes`` is either:
+
+    - A bare ``int`` — a regular step size that repeats to cover the axis
+      (the spec's single-integer shorthand).
+    - A ``tuple[int, ...]`` — explicit per-chunk edge lengths (already
+      expanded from any RLE encoding).
+
+    This distinction matters for faithful round-tripping: a bare int
+    serializes back as a bare int, while a single-element tuple serializes
+    as a list.
     """
 
-    chunk_shapes: tuple[tuple[int, ...], ...]
+    chunk_shapes: tuple[int | tuple[int, ...], ...]
 
     def __post_init__(self) -> None:
-        chunk_shapes_parsed = _validate_chunk_shapes(self.chunk_shapes)
-        object.__setattr__(self, "chunk_shapes", chunk_shapes_parsed)
+        from zarr.core.config import config
+
+        if not config.get("array.rectilinear_chunks"):
+            raise ValueError(
+                "Rectilinear chunk grids are experimental and disabled by default. "
+                "Enable them with: zarr.config.set({'array.rectilinear_chunks': True}) "
+                "or set the environment variable ZARR_ARRAY__RECTILINEAR_CHUNKS=True"
+            )
+        object.__setattr__(self, "chunk_shapes", _validate_chunk_shapes(self.chunk_shapes))
 
     @property
     def ndim(self) -> int:
@@ -284,17 +298,17 @@ class RectilinearChunkGrid(Metadata):
 
     def to_dict(self) -> RectilinearChunkGridJSON:  # type: ignore[override]
         serialized_dims: list[RectilinearDimSpecJSON] = []
-        for edges in self.chunk_shapes:
-            if len(edges) == 1:
-                # Bare int shorthand: single edge length repeated until sum >= extent
-                serialized_dims.append(edges[0])
+        for dim_spec in self.chunk_shapes:
+            if isinstance(dim_spec, int):
+                # Bare int shorthand — serialize as-is
+                serialized_dims.append(dim_spec)
             else:
-                rle = compress_rle(edges)
+                rle = compress_rle(dim_spec)
                 # Use RLE only if it's actually shorter
-                if len(rle) < len(edges):
+                if len(rle) < len(dim_spec):
                     serialized_dims.append(rle)
                 else:
-                    serialized_dims.append(list(edges))
+                    serialized_dims.append(list(dim_spec))
         return {
             "name": "rectilinear",
             "configuration": {
@@ -308,17 +322,23 @@ class RectilinearChunkGrid(Metadata):
     ) -> RectilinearChunkGrid:
         """Return a new RectilinearChunkGrid with edges adjusted for *new_shape*.
 
-        Grow past existing edges: appends a chunk covering the additional extent.
-        Shrink or grow within existing edges: edges are kept as-is (the spec
-        allows trailing edges beyond the array extent).
+        - Bare-int dimensions stay as bare ints (they cover any extent).
+        - Explicit-edge dimensions: if the new extent exceeds the sum of
+          edges, a new chunk is appended to cover the additional extent.
+          Otherwise edges are kept as-is (the spec allows trailing edges
+          beyond the array extent).
         """
-        new_chunk_shapes: list[tuple[int, ...]] = []
-        for edges, new_ext in zip(self.chunk_shapes, new_shape, strict=True):
-            edge_sum = sum(edges)
-            if new_ext > edge_sum:
-                new_chunk_shapes.append((*edges, new_ext - edge_sum))
+        new_chunk_shapes: list[int | tuple[int, ...]] = []
+        for dim_spec, new_ext in zip(self.chunk_shapes, new_shape, strict=True):
+            if isinstance(dim_spec, int):
+                # Bare int covers any extent — no change needed
+                new_chunk_shapes.append(dim_spec)
             else:
-                new_chunk_shapes.append(edges)
+                edge_sum = sum(dim_spec)
+                if new_ext > edge_sum:
+                    new_chunk_shapes.append((*dim_spec, new_ext - edge_sum))
+                else:
+                    new_chunk_shapes.append(dim_spec)
         return RectilinearChunkGrid(chunk_shapes=tuple(new_chunk_shapes))
 
     @classmethod
@@ -327,28 +347,25 @@ class RectilinearChunkGrid(Metadata):
         configuration = data["configuration"]
         validate_rectilinear_kind(configuration.get("kind"))
         raw_shapes = configuration["chunk_shapes"]
-        expanded: list[tuple[int, ...]] = []
+        parsed: list[int | tuple[int, ...]] = []
         for dim_spec in raw_shapes:
             if isinstance(dim_spec, int):
-                # Bare int shorthand — uniform edge length for this dimension.
-                # The DTO stores the single edge length; the behavioral ChunkGrid
-                # will repeat it to match the array extent when constructed.
                 if dim_spec < 1:
                     raise ValueError(f"Integer chunk edge length must be >= 1, got {dim_spec}")
-                expanded.append((dim_spec,))
+                parsed.append(dim_spec)
             elif isinstance(dim_spec, list):
-                expanded.append(tuple(expand_rle(dim_spec)))
+                parsed.append(tuple(expand_rle(dim_spec)))
             else:
                 raise TypeError(
                     f"Invalid chunk_shapes entry: expected int or list, got {type(dim_spec)}"
                 )
-        return cls(chunk_shapes=tuple(expanded))
+        return cls(chunk_shapes=tuple(parsed))
 
 
 ChunkGridMetadata = RegularChunkGrid | RectilinearChunkGrid
 
 
-def parse_chunk_grid(
+def parse_chunk_grid_metadata(
     data: dict[str, JSON] | ChunkGridMetadata | NamedConfig[str, Any],
 ) -> ChunkGridMetadata:
     """Parse a chunk grid from a metadata dict or pass through an existing instance."""
@@ -418,7 +435,7 @@ class ArrayV3Metadata(Metadata):
         """
 
         shape_parsed = parse_shapelike(shape)
-        chunk_grid_parsed = parse_chunk_grid(chunk_grid)
+        chunk_grid_parsed = parse_chunk_grid_metadata(chunk_grid)
         chunk_key_encoding_parsed = parse_chunk_key_encoding(chunk_key_encoding)
         dimension_names_parsed = parse_dimension_names(dimension_names)
         # Note: relying on a type method is numpy-specific

--- a/src/zarr/core/metadata/v3.py
+++ b/src/zarr/core/metadata/v3.py
@@ -379,7 +379,7 @@ def resolve_chunks(
 
     See Also
     --------
-    parse_chunk_grid_metadata : Deserialize a chunk grid from stored JSON metadata.
+    parse_chunk_grid : Deserialize a chunk grid from stored JSON metadata.
     """
     from zarr.core.chunk_grids import _is_rectilinear_chunks, normalize_chunks
 
@@ -389,7 +389,7 @@ def resolve_chunks(
     return RegularChunkGrid(chunk_shape=normalize_chunks(chunks, shape, typesize))
 
 
-def parse_chunk_grid_metadata(
+def parse_chunk_grid(
     data: dict[str, JSON] | ChunkGridMetadata | NamedConfig[str, Any],
 ) -> ChunkGridMetadata:
     """Deserialize a chunk grid from stored JSON metadata or pass through an existing instance.
@@ -464,7 +464,7 @@ class ArrayV3Metadata(Metadata):
         """
 
         shape_parsed = parse_shapelike(shape)
-        chunk_grid_parsed = parse_chunk_grid_metadata(chunk_grid)
+        chunk_grid_parsed = parse_chunk_grid(chunk_grid)
         chunk_key_encoding_parsed = parse_chunk_key_encoding(chunk_key_encoding)
         dimension_names_parsed = parse_dimension_names(dimension_names)
         # Note: relying on a type method is numpy-specific

--- a/tests/test_unified_chunk_grid.py
+++ b/tests/test_unified_chunk_grid.py
@@ -24,7 +24,7 @@ from zarr.core.chunk_grids import (
 from zarr.core.common import compress_rle, expand_rle
 from zarr.core.metadata.v3 import (
     RectilinearChunkGrid,
-    parse_chunk_grid_metadata,
+    parse_chunk_grid,
 )
 from zarr.core.metadata.v3 import (
     RegularChunkGrid as RegularChunkGridMeta,
@@ -657,7 +657,7 @@ def test_serialization_error_zero_extent_rectilinear() -> None:
 def test_serialization_unknown_name_parse() -> None:
     """Parsing metadata with an unknown chunk grid name raises ValueError"""
     with pytest.raises(ValueError, match="Unknown chunk grid"):
-        parse_chunk_grid_metadata({"name": "hexagonal", "configuration": {}})
+        parse_chunk_grid({"name": "hexagonal", "configuration": {}})
 
 
 # ---------------------------------------------------------------------------
@@ -672,7 +672,7 @@ def test_spec_kind_inline_required_on_deserialize() -> None:
         "configuration": {"chunk_shapes": [[10, 20], [15, 15]]},
     }
     with pytest.raises(ValueError, match="requires a 'kind' field"):
-        parse_chunk_grid_metadata(data)
+        parse_chunk_grid(data)
 
 
 def test_spec_kind_unknown_rejected() -> None:
@@ -682,7 +682,7 @@ def test_spec_kind_unknown_rejected() -> None:
         "configuration": {"kind": "reference", "chunk_shapes": [[10, 20], [15, 15]]},
     }
     with pytest.raises(ValueError, match="Unsupported rectilinear chunk grid kind"):
-        parse_chunk_grid_metadata(data)
+        parse_chunk_grid(data)
 
 
 def test_spec_integer_shorthand_per_dimension() -> None:
@@ -691,7 +691,7 @@ def test_spec_integer_shorthand_per_dimension() -> None:
         "name": "rectilinear",
         "configuration": {"kind": "inline", "chunk_shapes": [4, [1, 2, 3]]},
     }
-    meta = parse_chunk_grid_metadata(data)
+    meta = parse_chunk_grid(data)
     g = ChunkGrid.from_sizes((6, 6), meta.chunk_shapes)  # type: ignore[union-attr]
     assert _edges(g, 0) == (4, 4)
     assert _edges(g, 1) == (1, 2, 3)
@@ -703,7 +703,7 @@ def test_spec_mixed_rle_and_bare_integers() -> None:
         "name": "rectilinear",
         "configuration": {"kind": "inline", "chunk_shapes": [[[1, 3], 3]]},
     }
-    meta = parse_chunk_grid_metadata(data)
+    meta = parse_chunk_grid(data)
     g = ChunkGrid.from_sizes((6,), meta.chunk_shapes)  # type: ignore[union-attr]
     assert _edges(g, 0) == (1, 1, 1, 3)
 
@@ -714,7 +714,7 @@ def test_spec_overflow_chunks_allowed() -> None:
         "name": "rectilinear",
         "configuration": {"kind": "inline", "chunk_shapes": [[4, 4, 4]]},
     }
-    meta = parse_chunk_grid_metadata(data)
+    meta = parse_chunk_grid(data)
     g = ChunkGrid.from_sizes((6,), meta.chunk_shapes)  # type: ignore[union-attr]
     assert _edges(g, 0) == (4, 4, 4)
 
@@ -734,7 +734,7 @@ def test_spec_example() -> None:
             ],
         },
     }
-    meta = parse_chunk_grid_metadata(data)
+    meta = parse_chunk_grid(data)
     g = ChunkGrid.from_sizes((6, 6, 6, 6, 6), meta.chunk_shapes)  # type: ignore[union-attr]
     assert _edges(g, 0) == (4, 4)
     assert _edges(g, 1) == (1, 2, 3)
@@ -786,7 +786,7 @@ def test_parse_chunk_grid_rectilinear_extent_mismatch_raises(
         "name": "rectilinear",
         "configuration": {"kind": "inline", "chunk_shapes": chunk_shapes},
     }
-    meta = parse_chunk_grid_metadata(data)
+    meta = parse_chunk_grid(data)
     with pytest.raises(ValueError, match=match):
         ChunkGrid.from_sizes(array_shape, meta.chunk_shapes)  # type: ignore[union-attr]
 
@@ -797,7 +797,7 @@ def test_parse_chunk_grid_rectilinear_extent_match_passes() -> None:
         "name": "rectilinear",
         "configuration": {"kind": "inline", "chunk_shapes": [[10, 20, 30], [25, 25]]},
     }
-    meta = parse_chunk_grid_metadata(data)
+    meta = parse_chunk_grid(data)
     g = ChunkGrid.from_sizes((60, 50), meta.chunk_shapes)  # type: ignore[union-attr]
     assert g.grid_shape == (3, 2)
 
@@ -808,7 +808,7 @@ def test_parse_chunk_grid_rectilinear_ndim_mismatch_raises() -> None:
         "name": "rectilinear",
         "configuration": {"kind": "inline", "chunk_shapes": [[10, 20], [25, 25]]},
     }
-    meta = parse_chunk_grid_metadata(data)
+    meta = parse_chunk_grid(data)
     with pytest.raises(ValueError, match="3 dimensions but chunk_sizes has 2"):
         ChunkGrid.from_sizes((30, 50, 100), meta.chunk_shapes)  # type: ignore[union-attr]
 
@@ -819,7 +819,7 @@ def test_parse_chunk_grid_rectilinear_rle_extent_validated() -> None:
         "name": "rectilinear",
         "configuration": {"kind": "inline", "chunk_shapes": [[[10, 5]], [[25, 2]]]},
     }
-    meta = parse_chunk_grid_metadata(data)
+    meta = parse_chunk_grid(data)
     g = ChunkGrid.from_sizes((50, 50), meta.chunk_shapes)  # type: ignore[union-attr]
     assert g.grid_shape == (5, 2)
     with pytest.raises(ValueError, match="extent 100 exceeds sum of edges 50"):
@@ -1724,7 +1724,7 @@ def test_pipeline_nchunks(tmp_path: Path) -> None:
 def test_pipeline_parse_chunk_grid_regular_from_dict() -> None:
     """parse_chunk_grid constructs a regular grid from a metadata dict."""
     d: dict[str, Any] = {"name": "regular", "configuration": {"chunk_shape": [10, 20]}}
-    meta = parse_chunk_grid_metadata(d)
+    meta = parse_chunk_grid(d)
     assert isinstance(meta, RegularChunkGridMeta)
     g = ChunkGrid.from_sizes((100, 200), tuple(meta.chunk_shape))
     assert g.is_regular

--- a/tests/test_unified_chunk_grid.py
+++ b/tests/test_unified_chunk_grid.py
@@ -8,7 +8,6 @@ and end-to-end array creation + read/write.
 
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -21,13 +20,16 @@ from zarr.core.chunk_grids import (
     FixedDimension,
     VaryingDimension,
     _decode_dim_spec,
-    _infer_chunk_grid_name,
     _is_rectilinear_chunks,
-    parse_chunk_grid,
-    serialize_chunk_grid,
 )
 from zarr.core.common import compress_rle, expand_rle
-from zarr.core.metadata.v3 import RectilinearChunkGrid
+from zarr.core.metadata.v3 import (
+    RectilinearChunkGrid,
+    parse_chunk_grid_metadata,
+)
+from zarr.core.metadata.v3 import (
+    RegularChunkGrid as RegularChunkGridMeta,
+)
 from zarr.errors import BoundsCheckError
 from zarr.storage import MemoryStore
 
@@ -43,6 +45,19 @@ def _enable_rectilinear_chunks() -> Generator[None, None, None]:
         yield
 
 
+def _serialize_via_dto(grid: ChunkGrid) -> dict[str, Any]:
+    """Serialize a ChunkGrid via the metadata DTO path (replaces removed serialize_chunk_grid)."""
+    if grid.is_regular:
+        meta = RegularChunkGridMeta(chunk_shape=grid.chunk_shape)
+        return meta.to_dict()
+    else:
+        chunk_shapes: tuple[int | tuple[int, ...], ...] = tuple(
+            dim.size if isinstance(dim, FixedDimension) else dim.edges for dim in grid.dimensions
+        )
+        meta_r = RectilinearChunkGrid(chunk_shapes=chunk_shapes)
+        return meta_r.to_dict()
+
+
 def _edges(grid: ChunkGrid, dim: int) -> tuple[int, ...]:
     """Extract the per-chunk edge lengths for *dim* from a ChunkGrid."""
     d = grid.dimensions[dim]
@@ -53,1759 +68,2853 @@ def _edges(grid: ChunkGrid, dim: int) -> tuple[int, ...]:
     raise TypeError(f"Unexpected dimension type: {type(d)}")
 
 
-class TestVaryingDimensionIndexToChunkBounds:
-    def test_index_at_extent_raises(self) -> None:
-        """index_to_chunk(extent) should raise since extent is out of bounds."""
-        dim = VaryingDimension([10, 20, 30], extent=60)
-        with pytest.raises(IndexError, match="out of bounds"):
-            dim.index_to_chunk(60)
-
-    def test_index_past_extent_raises(self) -> None:
-        dim = VaryingDimension([10, 20, 30], extent=60)
-        with pytest.raises(IndexError, match="out of bounds"):
-            dim.index_to_chunk(100)
-
-    def test_last_valid_index_works(self) -> None:
-        dim = VaryingDimension([10, 20, 30], extent=60)
-        assert dim.index_to_chunk(59) == 2
+# ---------------------------------------------------------------------------
+# Dimension index_to_chunk bounds tests
+# ---------------------------------------------------------------------------
 
 
-class TestFixedDimensionIndexToChunkBounds:
-    def test_negative_index_raises(self) -> None:
-        """index_to_chunk(-1) should raise, not silently return -1."""
-        dim = FixedDimension(size=10, extent=95)
-        with pytest.raises(IndexError, match="Negative"):
-            dim.index_to_chunk(-1)
-
-    def test_index_at_extent_raises(self) -> None:
-        dim = FixedDimension(size=10, extent=95)
-        with pytest.raises(IndexError, match="out of bounds"):
-            dim.index_to_chunk(95)
-
-    def test_last_valid_index_works(self) -> None:
-        dim = FixedDimension(size=10, extent=95)
-        assert dim.index_to_chunk(94) == 9
-
-
-class TestRectilinearFeatureFlag:
-    """Test that rectilinear chunks are gated behind the config flag."""
-
-    def test_disabled_by_default(self) -> None:
-        with zarr.config.set({"array.rectilinear_chunks": False}):
-            with pytest.raises(ValueError, match="experimental and disabled by default"):
-                ChunkGrid.from_rectilinear([[10, 20], [25, 25]], array_shape=(30, 50))
-
-    def test_enabled_via_config(self) -> None:
-        with zarr.config.set({"array.rectilinear_chunks": True}):
-            g = ChunkGrid.from_rectilinear([[10, 20], [25, 25]], array_shape=(30, 50))
-            assert g.ndim == 2
-
-    def test_create_array_blocked(self) -> None:
-        with zarr.config.set({"array.rectilinear_chunks": False}):
-            store = MemoryStore()
-            with pytest.raises(ValueError, match="experimental and disabled by default"):
-                zarr.create_array(store, shape=(30,), chunks=[[10, 20]], dtype="int32")
-
-    def test_parse_chunk_grid_blocked(self) -> None:
-        """Opening a rectilinear array from metadata is also gated."""
-        with zarr.config.set({"array.rectilinear_chunks": False}):
-            with pytest.raises(ValueError, match="experimental and disabled by default"):
-                parse_chunk_grid(
-                    {
-                        "name": "rectilinear",
-                        "configuration": {
-                            "kind": "inline",
-                            "chunk_shapes": [[10, 20, 30], [50, 50]],
-                        },
-                    },
-                    array_shape=(60, 100),
-                )
+@pytest.mark.parametrize(
+    ("dim", "index", "match"),
+    [
+        (VaryingDimension([10, 20, 30], extent=60), 60, "out of bounds"),
+        (VaryingDimension([10, 20, 30], extent=60), 100, "out of bounds"),
+        (FixedDimension(size=10, extent=95), 95, "out of bounds"),
+        (FixedDimension(size=10, extent=95), -1, "Negative"),
+    ],
+    ids=[
+        "varying-at-extent",
+        "varying-past-extent",
+        "fixed-at-extent",
+        "fixed-negative",
+    ],
+)
+def test_dimension_index_to_chunk_bounds(
+    dim: FixedDimension | VaryingDimension, index: int, match: str
+) -> None:
+    """Out-of-bounds or negative indices raise IndexError for both dimension types"""
+    with pytest.raises(IndexError, match=match):
+        dim.index_to_chunk(index)
 
 
-class TestRegularChunkGridCompat:
-    """The deprecated RegularChunkGrid shim should work for common patterns."""
-
-    def test_construction_emits_deprecation_warning(self) -> None:
-        from zarr.core.chunk_grids import RegularChunkGrid
-
-        with pytest.warns(DeprecationWarning, match="RegularChunkGrid is deprecated"):
-            grid = RegularChunkGrid(chunk_shape=(10, 20))
-        assert isinstance(grid, ChunkGrid)
-        assert grid.is_regular
-        assert grid.chunk_shape == (10, 20)
-
-    def test_isinstance_check(self) -> None:
-        from zarr.core.chunk_grids import RegularChunkGrid
-
-        grid = ChunkGrid.from_regular((100, 200), (10, 20))
-        assert isinstance(grid, RegularChunkGrid)
-
-    def test_isinstance_false_for_rectilinear(self) -> None:
-        from zarr.core.chunk_grids import RegularChunkGrid
-
-        grid = ChunkGrid.from_rectilinear([[10, 20], [25, 25]], array_shape=(30, 50))
-        assert not isinstance(grid, RegularChunkGrid)
-
-    def test_isinstance_false_for_unrelated_types(self) -> None:
-        from zarr.core.chunk_grids import RegularChunkGrid
-
-        assert not isinstance("hello", RegularChunkGrid)
-        assert not isinstance(42, RegularChunkGrid)
+@pytest.mark.parametrize(
+    ("dim", "index", "expected"),
+    [
+        (VaryingDimension([10, 20, 30], extent=60), 59, 2),
+        (FixedDimension(size=10, extent=95), 94, 9),
+    ],
+    ids=["varying-last-valid", "fixed-last-valid"],
+)
+def test_dimension_index_to_chunk_last_valid(
+    dim: FixedDimension | VaryingDimension, index: int, expected: int
+) -> None:
+    """Last valid index maps to the correct chunk for both dimension types"""
+    assert dim.index_to_chunk(index) == expected
 
 
-class TestFixedDimension:
-    def test_basic(self) -> None:
-        d = FixedDimension(size=10, extent=100)
-        assert d.size == 10
-        assert d.extent == 100
-        assert d.index_to_chunk(0) == 0
-        assert d.index_to_chunk(9) == 0
-        assert d.index_to_chunk(10) == 1
-        assert d.index_to_chunk(25) == 2
-        assert d.chunk_offset(0) == 0
-        assert d.chunk_offset(1) == 10
-        assert d.chunk_offset(3) == 30
-        # chunk_size is always uniform (codec buffer)
-        assert d.chunk_size(0) == 10
-        assert d.chunk_size(9) == 10
-        assert d.data_size(0) == 10
-        assert d.data_size(9) == 10
-        assert d.nchunks == 10
-
-    def test_boundary_data_size(self) -> None:
-        d = FixedDimension(size=10, extent=95)
-        assert d.nchunks == 10
-        assert d.chunk_size(9) == 10
-        assert d.data_size(9) == 5
-
-    def test_vectorized(self) -> None:
-        d = FixedDimension(size=10, extent=100)
-        indices = np.array([0, 5, 10, 15, 99])
-        chunks = d.indices_to_chunks(indices)
-        np.testing.assert_array_equal(chunks, [0, 0, 1, 1, 9])
-
-    def test_negative_size_rejected(self) -> None:
-        with pytest.raises(ValueError, match="must be >= 0"):
-            FixedDimension(size=-1, extent=100)
-
-    def test_negative_extent_rejected(self) -> None:
-        with pytest.raises(ValueError, match="must be >= 0"):
-            FixedDimension(size=10, extent=-1)
-
-    def test_zero_size_allowed(self) -> None:
-        d = FixedDimension(size=0, extent=0)
-        assert d.size == 0
-        assert d.nchunks == 0
-
-    # FixedDimension.chunk_offset/chunk_size/data_size do not bounds-check
-    # for performance (callers validate). OOB access is tested via
-    # ChunkGrid.__getitem__ which checks before delegating.
+# ---------------------------------------------------------------------------
+# Rectilinear feature flag tests
+# ---------------------------------------------------------------------------
 
 
-class TestVaryingDimension:
-    def test_basic(self) -> None:
-        d = VaryingDimension([10, 20, 30], extent=60)
-        assert d.edges == (10, 20, 30)
-        assert d.cumulative == (10, 30, 60)
-        assert d.nchunks == 3
-        assert d.extent == 60
-
-    def test_index_to_chunk(self) -> None:
-        d = VaryingDimension([10, 20, 30], extent=60)
-        assert d.index_to_chunk(0) == 0
-        assert d.index_to_chunk(9) == 0
-        assert d.index_to_chunk(10) == 1
-        assert d.index_to_chunk(29) == 1
-        assert d.index_to_chunk(30) == 2
-        assert d.index_to_chunk(59) == 2
-
-    def test_chunk_offset(self) -> None:
-        d = VaryingDimension([10, 20, 30], extent=60)
-        assert d.chunk_offset(0) == 0
-        assert d.chunk_offset(1) == 10
-        assert d.chunk_offset(2) == 30
-
-    def test_chunk_size(self) -> None:
-        d = VaryingDimension([10, 20, 30], extent=60)
-        assert d.chunk_size(0) == 10
-        assert d.chunk_size(1) == 20
-        assert d.chunk_size(2) == 30
-
-    def test_data_size(self) -> None:
-        d = VaryingDimension([10, 20, 30], extent=60)
-        assert d.data_size(0) == 10
-        assert d.data_size(1) == 20
-        assert d.data_size(2) == 30
-
-    def test_vectorized(self) -> None:
-        d = VaryingDimension([10, 20, 30], extent=60)
-        indices = np.array([0, 9, 10, 29, 30, 59])
-        chunks = d.indices_to_chunks(indices)
-        np.testing.assert_array_equal(chunks, [0, 0, 1, 1, 2, 2])
-
-    def test_empty_rejected(self) -> None:
-        with pytest.raises(ValueError, match="must not be empty"):
-            VaryingDimension([], extent=0)
-
-    def test_zero_edge_rejected(self) -> None:
-        with pytest.raises(ValueError, match="must be > 0"):
-            VaryingDimension([10, 0, 5], extent=15)
+@pytest.mark.parametrize(
+    "action",
+    [
+        lambda: RectilinearChunkGrid(chunk_shapes=((10, 20), (25, 25))),
+        lambda: RectilinearChunkGrid.from_dict(
+            {
+                "name": "rectilinear",
+                "configuration": {"kind": "inline", "chunk_shapes": [[10, 20, 30], [50, 50]]},
+            }
+        ),
+        lambda: zarr.create_array(MemoryStore(), shape=(30,), chunks=[[10, 20]], dtype="int32"),
+    ],
+    ids=["constructor", "from_dict", "create_array"],
+)
+def test_rectilinear_feature_flag_blocked(action: Any) -> None:
+    """Rectilinear chunk operations raise ValueError when the feature flag is disabled"""
+    with zarr.config.set({"array.rectilinear_chunks": False}):
+        with pytest.raises(ValueError, match="experimental and disabled by default"):
+            action()
 
 
-class TestChunkSpec:
-    def test_basic(self) -> None:
-        spec = ChunkSpec(
-            slices=(slice(0, 10), slice(0, 20)),
-            codec_shape=(10, 20),
-        )
-        assert spec.shape == (10, 20)
-        assert not spec.is_boundary
-
-    def test_boundary(self) -> None:
-        spec = ChunkSpec(
-            slices=(slice(90, 95), slice(0, 20)),
-            codec_shape=(10, 20),
-        )
-        assert spec.shape == (5, 20)
-        assert spec.is_boundary
+def test_rectilinear_feature_flag_enabled() -> None:
+    """Rectilinear chunk grid construction succeeds when the feature flag is enabled"""
+    with zarr.config.set({"array.rectilinear_chunks": True}):
+        grid = RectilinearChunkGrid(chunk_shapes=((10, 20), (25, 25)))
+        assert grid.ndim == 2
 
 
-class TestChunkGridConstruction:
-    def test_from_regular(self) -> None:
-        g = ChunkGrid.from_regular((100, 200), (10, 20))
-        assert g.is_regular
-        assert g.chunk_shape == (10, 20)
-        assert g.ndim == 2
+# ---------------------------------------------------------------------------
+# RegularChunkGrid compatibility tests
+# ---------------------------------------------------------------------------
 
-    def test_zero_dim(self) -> None:
-        """0-d arrays produce a ChunkGrid with no dimensions."""
-        g = ChunkGrid.from_regular((), ())
-        assert g.is_regular
-        assert g.chunk_shape == ()
-        assert g.ndim == 0
 
-    def test_from_rectilinear(self) -> None:
-        g = ChunkGrid.from_rectilinear([[10, 20, 30], [25, 25, 25, 25]], array_shape=(60, 100))
-        assert not g.is_regular
-        assert g.ndim == 2
+def test_regular_chunk_grid_compat_construction_emits_deprecation_warning() -> None:
+    """Constructing RegularChunkGrid emits a DeprecationWarning and returns a ChunkGrid"""
+    from zarr.core.chunk_grids import RegularChunkGrid
+
+    with pytest.warns(DeprecationWarning, match="RegularChunkGrid is deprecated"):
+        grid = RegularChunkGrid(chunk_shape=(10, 20))
+    assert isinstance(grid, ChunkGrid)
+    assert grid.is_regular
+    assert grid.chunk_shape == (10, 20)
+
+
+@pytest.mark.parametrize(
+    ("grid", "expected"),
+    [
+        (ChunkGrid.from_sizes((100, 200), (10, 20)), True),
+        (ChunkGrid.from_sizes((30, 50), [[10, 20], [25, 25]]), False),
+    ],
+    ids=["regular-is-instance", "rectilinear-is-not-instance"],
+)
+def test_regular_chunk_grid_isinstance(grid: ChunkGrid, expected: bool) -> None:
+    """isinstance check against RegularChunkGrid matches only regular grids"""
+    from zarr.core.chunk_grids import RegularChunkGrid
+
+    assert isinstance(grid, RegularChunkGrid) == expected
+
+
+@pytest.mark.parametrize("obj", ["hello", 42], ids=["string", "int"])
+def test_regular_chunk_grid_isinstance_false_for_unrelated_types(obj: Any) -> None:
+    """Unrelated types are not instances of RegularChunkGrid"""
+    from zarr.core.chunk_grids import RegularChunkGrid
+
+    assert not isinstance(obj, RegularChunkGrid)
+
+
+# ---------------------------------------------------------------------------
+# FixedDimension tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    (
+        "size",
+        "extent",
+        "chunk_ix",
+        "expected_nchunks",
+        "expected_chunk_size",
+        "expected_data_size",
+        "expected_offset",
+    ),
+    [
+        (10, 100, 0, 10, 10, 10, 0),
+        (10, 100, 1, 10, 10, 10, 10),
+        (10, 100, 9, 10, 10, 10, 90),
+        (10, 95, 9, 10, 10, 5, 90),  # boundary chunk
+        (0, 0, None, 0, None, None, None),  # zero-size
+    ],
+    ids=["start", "middle", "end", "boundary", "zero-size"],
+)
+def test_fixed_dimension(
+    size: int,
+    extent: int,
+    chunk_ix: int | None,
+    expected_nchunks: int,
+    expected_chunk_size: int | None,
+    expected_data_size: int | None,
+    expected_offset: int | None,
+) -> None:
+    """FixedDimension properties match expected values for various chunk/extent combinations"""
+    d = FixedDimension(size=size, extent=extent)
+    assert d.nchunks == expected_nchunks
+    if chunk_ix is not None:
+        assert d.chunk_size(chunk_ix) == expected_chunk_size
+        assert d.data_size(chunk_ix) == expected_data_size
+        assert d.chunk_offset(chunk_ix) == expected_offset
+
+
+@pytest.mark.parametrize(
+    ("idx", "expected"),
+    [(0, 0), (9, 0), (10, 1), (25, 2)],
+)
+def test_fixed_dimension_index_to_chunk(idx: int, expected: int) -> None:
+    """FixedDimension.index_to_chunk maps element indices to correct chunk indices"""
+    d = FixedDimension(size=10, extent=100)
+    assert d.index_to_chunk(idx) == expected
+
+
+def test_fixed_dimension_indices_to_chunks() -> None:
+    """FixedDimension.indices_to_chunks vectorizes index-to-chunk mapping over an array"""
+    d = FixedDimension(size=10, extent=100)
+    indices = np.array([0, 5, 10, 15, 99])
+    np.testing.assert_array_equal(d.indices_to_chunks(indices), [0, 0, 1, 1, 9])
+
+
+@pytest.mark.parametrize(
+    ("size", "extent", "match"),
+    [(-1, 100, "must be >= 0"), (10, -1, "must be >= 0")],
+    ids=["negative-size", "negative-extent"],
+)
+def test_fixed_dimension_rejects_negative(size: int, extent: int, match: str) -> None:
+    """FixedDimension raises ValueError for negative size or extent"""
+    with pytest.raises(ValueError, match=match):
+        FixedDimension(size=size, extent=extent)
+
+
+# ---------------------------------------------------------------------------
+# VaryingDimension tests
+# ---------------------------------------------------------------------------
+
+
+def test_varying_dimension_construction() -> None:
+    """VaryingDimension stores edges, cumulative sums, nchunks, and extent correctly"""
+    d = VaryingDimension([10, 20, 30], extent=60)
+    assert d.edges == (10, 20, 30)
+    assert d.cumulative == (10, 30, 60)
+    assert d.nchunks == 3
+    assert d.extent == 60
+
+
+@pytest.mark.parametrize(
+    (
+        "chunk_idx",
+        "expected_offset",
+        "expected_size",
+        "expected_data",
+        "expected_chunk_for_first_idx",
+    ),
+    [
+        (0, 0, 10, 10, 0),
+        (1, 10, 20, 20, 1),
+        (2, 30, 30, 30, 2),
+    ],
+)
+def test_varying_dimension(
+    chunk_idx: int,
+    expected_offset: int,
+    expected_size: int,
+    expected_data: int,
+    expected_chunk_for_first_idx: int,
+) -> None:
+    """VaryingDimension chunk_offset, chunk_size, data_size, and index_to_chunk return correct values"""
+    d = VaryingDimension([10, 20, 30], extent=60)
+    assert d.chunk_offset(chunk_idx) == expected_offset
+    assert d.chunk_size(chunk_idx) == expected_size
+    assert d.data_size(chunk_idx) == expected_data
+    assert d.index_to_chunk(expected_offset) == expected_chunk_for_first_idx
+
+
+def test_varying_dimension_indices_to_chunks() -> None:
+    """VaryingDimension.indices_to_chunks vectorizes index-to-chunk mapping over an array"""
+    d = VaryingDimension([10, 20, 30], extent=60)
+    indices = np.array([0, 9, 10, 29, 30, 59])
+    np.testing.assert_array_equal(d.indices_to_chunks(indices), [0, 0, 1, 1, 2, 2])
+
+
+@pytest.mark.parametrize(
+    ("edges", "extent", "match"),
+    [
+        ([], 0, "must not be empty"),
+        ([10, 0, 5], 15, "must be > 0"),
+    ],
+    ids=["empty", "zero-edge"],
+)
+def test_varying_dimension_rejects_invalid(edges: list[int], extent: int, match: str) -> None:
+    """VaryingDimension raises ValueError for empty edges or zero-length edges"""
+    with pytest.raises(ValueError, match=match):
+        VaryingDimension(edges, extent=extent)
+
+
+# ---------------------------------------------------------------------------
+# ChunkSpec tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("slices", "codec_shape", "expected_shape", "expected_boundary"),
+    [
+        ((slice(0, 10), slice(0, 20)), (10, 20), (10, 20), False),
+        ((slice(90, 95), slice(0, 20)), (10, 20), (5, 20), True),
+        ((slice(10, 10),), (0,), (0,), False),
+        ((slice(0, 10), slice(0, 5)), (10, 10), (10, 5), True),
+    ],
+    ids=["basic", "boundary", "empty-slices", "multidim-boundary"],
+)
+def test_chunk_spec(
+    slices: tuple[slice, ...],
+    codec_shape: tuple[int, ...],
+    expected_shape: tuple[int, ...],
+    expected_boundary: bool,
+) -> None:
+    """ChunkSpec reports correct shape and boundary status from slices and codec_shape"""
+    spec = ChunkSpec(slices=slices, codec_shape=codec_shape)
+    assert spec.shape == expected_shape
+    assert spec.is_boundary == expected_boundary
+
+
+# ---------------------------------------------------------------------------
+# ChunkGrid construction tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("array_shape", "chunk_sizes", "expected_regular", "expected_ndim", "expected_chunk_shape"),
+    [
+        ((100, 200), (10, 20), True, 2, (10, 20)),
+        ((), (), True, 0, ()),
+        ((60, 100), [[10, 20, 30], [25, 25, 25, 25]], False, 2, None),
+        ((30, 50), [[10, 10, 10], [25, 25]], True, 2, (10, 25)),  # uniform edges → regular
+    ],
+    ids=["regular", "zero-dim", "rectilinear", "uniform-becomes-regular"],
+)
+def test_chunk_grid_construction(
+    array_shape: tuple[int, ...],
+    chunk_sizes: Any,
+    expected_regular: bool,
+    expected_ndim: int,
+    expected_chunk_shape: tuple[int, ...] | None,
+) -> None:
+    """ChunkGrid.from_sizes produces grids with correct regularity, ndim, and chunk_shape"""
+    g = ChunkGrid.from_sizes(array_shape, chunk_sizes)
+    assert g.is_regular == expected_regular
+    assert g.ndim == expected_ndim
+    if expected_chunk_shape is not None:
+        assert g.chunk_shape == expected_chunk_shape
+    else:
         with pytest.raises(ValueError, match="only available for regular"):
             _ = g.chunk_shape
 
-    def test_rectilinear_with_uniform_dim(self) -> None:
-        """A rectilinear grid with all-same sizes in one dim stores it as Fixed."""
-        g = ChunkGrid.from_rectilinear([[10, 20, 30], [25, 25, 25, 25]], array_shape=(60, 100))
-        assert isinstance(g.dimensions[0], VaryingDimension)
-        assert isinstance(g.dimensions[1], FixedDimension)
-
-    def test_all_uniform_becomes_regular(self) -> None:
-        """If all dimensions have uniform sizes, the grid is regular."""
-        g = ChunkGrid.from_rectilinear([[10, 10, 10], [25, 25]], array_shape=(30, 50))
-        assert g.is_regular
-        assert g.chunk_shape == (10, 25)
-
-
-class TestChunkGridQueries:
-    def test_regular_shape(self) -> None:
-        g = ChunkGrid.from_regular((100, 200), (10, 20))
-        assert g.grid_shape == (10, 10)
-
-    def test_regular_shape_boundary(self) -> None:
-        g = ChunkGrid.from_regular((95, 200), (10, 20))
-        assert g.grid_shape == (10, 10)
-
-    def test_rectilinear_shape(self) -> None:
-        g = ChunkGrid.from_rectilinear([[10, 20, 30], [25, 25, 25, 25]], array_shape=(60, 100))
-        assert g.grid_shape == (3, 4)
-
-    def test_regular_getitem(self) -> None:
-        g = ChunkGrid.from_regular((100, 200), (10, 20))
-        spec = g[(0, 0)]
-        assert spec is not None
-        assert spec.shape == (10, 20)
-        assert spec.codec_shape == (10, 20)
-        assert not spec.is_boundary
-
-    def test_regular_getitem_boundary(self) -> None:
-        g = ChunkGrid.from_regular((95, 200), (10, 20))
-        spec = g[(9, 0)]
-        assert spec is not None
-        assert spec.shape == (5, 20)  # data_size clipped
-        assert spec.codec_shape == (10, 20)  # codec always full
-        assert spec.is_boundary
-
-    def test_regular_getitem_oob(self) -> None:
-        g = ChunkGrid.from_regular((100, 200), (10, 20))
-        assert g[(99, 0)] is None
-
-    def test_rectilinear_getitem(self) -> None:
-        g = ChunkGrid.from_rectilinear([[10, 20, 30], [25, 25, 25, 25]], array_shape=(60, 100))
-        spec0 = g[(0, 0)]
-        assert spec0 is not None
-        assert spec0.shape == (10, 25)
-
-        spec1 = g[(1, 0)]
-        assert spec1 is not None
-        assert spec1.shape == (20, 25)
-
-        spec2 = g[(2, 3)]
-        assert spec2 is not None
-        assert spec2.shape == (30, 25)
-
-        assert g[(3, 0)] is None  # OOB
-
-    def test_getitem_slices(self) -> None:
-        g = ChunkGrid.from_rectilinear([[10, 20, 30], [25, 25, 25, 25]], array_shape=(60, 100))
-        spec = g[(1, 2)]
-        assert spec is not None
-        assert spec.slices == (slice(10, 30, 1), slice(50, 75, 1))
-
-    def test_all_chunk_coords(self) -> None:
-        g = ChunkGrid.from_rectilinear([[10, 20, 30], [50, 50]], array_shape=(60, 100))
-        coords = list(g.all_chunk_coords())
-        assert len(coords) == 6
-        assert coords[0] == (0, 0)
-        assert coords[-1] == (2, 1)
-
-    def test_all_chunk_coords_with_origin(self) -> None:
-        g = ChunkGrid.from_rectilinear([[10, 20, 30], [50, 50]], array_shape=(60, 100))
-        coords = list(g.all_chunk_coords(origin=(1, 0)))
-        assert len(coords) == 4  # 2 remaining in dim0 * 2 in dim1
-        assert coords[0] == (1, 0)
-        assert coords[-1] == (2, 1)
-
-    def test_all_chunk_coords_with_selection_shape(self) -> None:
-        g = ChunkGrid.from_rectilinear([[10, 20, 30], [50, 50]], array_shape=(60, 100))
-        coords = list(g.all_chunk_coords(selection_shape=(2, 1)))
-        assert len(coords) == 2
-        assert coords == [(0, 0), (1, 0)]
-
-    def test_all_chunk_coords_with_origin_and_selection_shape(self) -> None:
-        g = ChunkGrid.from_rectilinear([[10, 20, 30], [50, 50]], array_shape=(60, 100))
-        coords = list(g.all_chunk_coords(origin=(1, 1), selection_shape=(2, 1)))
-        assert coords == [(1, 1), (2, 1)]
-
-    def test_all_chunk_coords_origin_at_last_chunk(self) -> None:
-        g = ChunkGrid.from_regular((30, 40), (10, 20))
-        coords = list(g.all_chunk_coords(origin=(2, 1)))
-        assert coords == [(2, 1)]
-
-    def test_all_chunk_coords_selection_shape_zero(self) -> None:
-        g = ChunkGrid.from_regular((30, 40), (10, 20))
-        coords = list(g.all_chunk_coords(selection_shape=(0, 0)))
-        assert coords == []
 
-    def test_all_chunk_coords_single_dim_slice(self) -> None:
-        """Origin shifts one dim, selection_shape restricts the other."""
-        g = ChunkGrid.from_regular((60, 80), (20, 20))  # 3x4
-        coords = list(g.all_chunk_coords(origin=(0, 2), selection_shape=(3, 1)))
-        assert coords == [(0, 2), (1, 2), (2, 2)]
-
-    def test_get_nchunks(self) -> None:
-        g = ChunkGrid.from_rectilinear([[10, 20, 30], [50, 50]], array_shape=(60, 100))
-        assert g.get_nchunks() == 6
-
-    def test_iter(self) -> None:
-        g = ChunkGrid.from_regular((30, 40), (10, 20))
-        specs = list(g)
-        assert len(specs) == 6  # 3 * 2
-        assert all(isinstance(s, ChunkSpec) for s in specs)
-
-
-class TestRLE:
-    def test_expand(self) -> None:
-        assert expand_rle([[10, 3]]) == [10, 10, 10]
-        assert expand_rle([[10, 2], [20, 1]]) == [10, 10, 20]
-
-    def test_compress(self) -> None:
-        assert compress_rle([10, 10, 10]) == [[10, 3]]
-        assert compress_rle([10, 10, 20]) == [[10, 2], 20]
-        assert compress_rle([5]) == [5]
-        assert compress_rle([10, 20, 30]) == [10, 20, 30]
-
-    def test_roundtrip(self) -> None:
-        original = [10, 10, 10, 20, 20, 30]
-        compressed = compress_rle(original)
-        assert expand_rle(compressed) == original
-
-    def test_expand_rejects_zero_edge(self) -> None:
-        with pytest.raises(ValueError, match="Chunk edge length must be >= 1"):
-            expand_rle([0])
-
-    def test_expand_rejects_negative_edge(self) -> None:
-        with pytest.raises(ValueError, match="Chunk edge length must be >= 1"):
-            expand_rle([-5])
-
-    def test_expand_rejects_zero_rle_size(self) -> None:
-        with pytest.raises(ValueError, match="Chunk edge length must be >= 1"):
-            expand_rle([[0, 3]])
-
-    def test_expand_rejects_negative_rle_size(self) -> None:
-        with pytest.raises(ValueError, match="Chunk edge length must be >= 1"):
-            expand_rle([[-10, 2]])
-
-    def test_expand_rejects_zero_rle_count(self) -> None:
-        with pytest.raises(ValueError, match="RLE repeat count must be >= 1"):
-            expand_rle([[5, 0]])
-
-    def test_expand_rejects_negative_rle_count(self) -> None:
-        with pytest.raises(ValueError, match="RLE repeat count must be >= 1"):
-            expand_rle([[5, -1]])
-
-
-class TestExpandRleHandlesJsonFloats:
-    def test_bare_integer_floats_accepted(self) -> None:
-        """JSON parsers may emit 10.0 for the integer 10; expand_rle should handle it."""
-        result = expand_rle([10.0, 20.0])  # type: ignore[list-item]
-        assert result == [10, 20]
-
-    def test_rle_pair_with_float_count(self) -> None:
-        result = expand_rle([[10, 3.0]])  # type: ignore[list-item]
-        assert result == [10, 10, 10]
-
-
-class TestDecodeDimSpec:
-    """Edge cases for _decode_dim_spec: floats, empty lists, negatives, missing extent."""
-
-    def test_bare_integer(self) -> None:
-        assert _decode_dim_spec(10, array_extent=25) == [10, 10, 10]
-
-    def test_bare_integer_exact_fit(self) -> None:
-        assert _decode_dim_spec(5, array_extent=10) == [5, 5]
-
-    def test_bare_integer_no_extent_raises(self) -> None:
-        with pytest.raises(ValueError, match="requires array shape"):
-            _decode_dim_spec(10, array_extent=None)
-
-    def test_bare_integer_zero_raises(self) -> None:
-        with pytest.raises(ValueError, match="must be > 0"):
-            _decode_dim_spec(0, array_extent=10)
-
-    def test_bare_integer_negative_raises(self) -> None:
-        with pytest.raises(ValueError, match="must be > 0"):
-            _decode_dim_spec(-5, array_extent=10)
-
-    def test_bare_float_raises(self) -> None:
-        """A bare float (not in a list) is not int or list — should raise."""
-        with pytest.raises(ValueError, match="Invalid chunk_shapes entry"):
-            _decode_dim_spec(10.0, array_extent=10)
-
-    def test_explicit_integer_list(self) -> None:
-        assert _decode_dim_spec([10, 20, 30]) == [10, 20, 30]
-
-    def test_empty_list(self) -> None:
-        """An empty list has no sub-lists, so it returns an empty explicit list."""
-        assert _decode_dim_spec([]) == []
-
-    def test_list_with_rle(self) -> None:
-        assert _decode_dim_spec([[5, 3], 10]) == [5, 5, 5, 10]
-
-    def test_string_raises(self) -> None:
-        with pytest.raises(ValueError, match="Invalid chunk_shapes entry"):
-            _decode_dim_spec("auto", array_extent=10)
-
-    def test_none_raises(self) -> None:
-        with pytest.raises(ValueError, match="Invalid chunk_shapes entry"):
-            _decode_dim_spec(None, array_extent=10)
-
-
-class TestIsRectilinearChunks:
-    """Edge cases for _is_rectilinear_chunks."""
-
-    def test_nested_lists(self) -> None:
-        assert _is_rectilinear_chunks([[10, 20], [5, 5]]) is True
-
-    def test_nested_tuples(self) -> None:
-        assert _is_rectilinear_chunks(((10, 20), (5, 5))) is True
-
-    def test_flat_tuple(self) -> None:
-        assert _is_rectilinear_chunks((10, 20)) is False
-
-    def test_flat_list(self) -> None:
-        assert _is_rectilinear_chunks([10, 20]) is False
-
-    def test_single_int(self) -> None:
-        assert _is_rectilinear_chunks(10) is False
-
-    def test_string(self) -> None:
-        assert _is_rectilinear_chunks("auto") is False
-
-    def test_empty_list(self) -> None:
-        assert _is_rectilinear_chunks([]) is False
-
-    def test_empty_nested_list(self) -> None:
-        """First element is an empty list — it's iterable and not str/int."""
-        assert _is_rectilinear_chunks([[]]) is True
-
-    def test_chunk_grid_instance(self) -> None:
-        g = ChunkGrid.from_regular((10,), (5,))
-        assert _is_rectilinear_chunks(g) is False
-
-    def test_none(self) -> None:
-        assert _is_rectilinear_chunks(None) is False
-
-    def test_float(self) -> None:
-        assert _is_rectilinear_chunks(3.14) is False
-
-
-class TestInferChunkGridName:
-    """Edge cases for _infer_chunk_grid_name."""
-
-    def test_regular_grid(self) -> None:
-        g = ChunkGrid.from_regular((100,), (10,))
-        assert _infer_chunk_grid_name(g, g) == "regular"
-
-    @pytest.fixture(autouse=True)
-    def _enable_rectilinear(self) -> Any:
-        with zarr.config.set({"array.rectilinear_chunks": True}):
-            yield
-
-    def test_rectilinear_grid(self) -> None:
-        g = ChunkGrid.from_rectilinear([[10, 20, 30]], array_shape=(60,))
-        assert _infer_chunk_grid_name(g, g) == "rectilinear"
-
-    def test_dict_with_regular_name(self) -> None:
-        g = ChunkGrid.from_regular((100,), (10,))
-        d: dict[str, Any] = {"name": "regular", "configuration": {"chunk_shape": [10]}}
-        assert _infer_chunk_grid_name(d, g) == "regular"
-
-    def test_dict_with_rectilinear_name(self) -> None:
-        g = ChunkGrid.from_regular((100,), (10,))
-        d: dict[str, Any] = {
-            "name": "rectilinear",
-            "configuration": {"kind": "inline", "chunk_shapes": [10]},
-        }
-        assert _infer_chunk_grid_name(d, g) == "rectilinear"
-
-
-class TestSerialization:
-    def test_regular_roundtrip(self) -> None:
-        g = ChunkGrid.from_regular((100, 200), (10, 20))
-        d = serialize_chunk_grid(g, "regular")
-        assert d["name"] == "regular"
-        config = d["configuration"]
-        assert isinstance(config, dict)
-        assert tuple(config["chunk_shape"]) == (10, 20)
-        g2 = parse_chunk_grid(d, (100, 200))
-        assert g2.is_regular
-        assert g2.chunk_shape == (10, 20)
-
-    def test_rectilinear_roundtrip(self) -> None:
-        g = ChunkGrid.from_rectilinear([[10, 20, 30], [25, 25, 25, 25]], array_shape=(60, 100))
-        d = serialize_chunk_grid(g, "rectilinear")
-        assert d["name"] == "rectilinear"
-        g2 = parse_chunk_grid(d, (60, 100))
-        assert not g2.is_regular
-        # Verify the reconstructed grid has same dimensions
-        spec0 = g2[(0, 0)]
-        assert spec0 is not None
-        assert spec0.shape == (10, 25)
-        spec1 = g2[(1, 0)]
-        assert spec1 is not None
-        assert spec1.shape == (20, 25)
-
-    def test_rectilinear_rle_serialization(self) -> None:
-        """RLE should be used when it actually compresses."""
-        g = ChunkGrid.from_rectilinear([[100] * 10, [25, 25, 25, 25]], array_shape=(1000, 100))
-        # All uniform, but name is chosen by the metadata layer, not the grid.
-        # Serializing as "regular" works because is_regular is True.
-        d = serialize_chunk_grid(g, "regular")
-        assert d["name"] == "regular"
-
-    def test_rectilinear_uniform_stays_rectilinear(self) -> None:
-        """A rectilinear grid with uniform edges stays rectilinear if the name says so."""
-        g = ChunkGrid.from_rectilinear([[100] * 10, [25, 25, 25, 25]], array_shape=(1000, 100))
-        d = serialize_chunk_grid(g, "rectilinear")
-        assert d["name"] == "rectilinear"
-
-    def test_rectilinear_rle_with_varying(self) -> None:
-        g = ChunkGrid.from_rectilinear(
-            [[100, 100, 100, 50], [25, 25, 25, 25]], array_shape=(350, 100)
-        )
-        d = serialize_chunk_grid(g, "rectilinear")
-        assert d["name"] == "rectilinear"
-        config = d["configuration"]
-        assert isinstance(config, dict)
-        chunk_shapes = config["chunk_shapes"]
-        assert isinstance(chunk_shapes, list)
-        assert chunk_shapes[0] == [[100, 3], 50]
-
-    def test_json_roundtrip(self) -> None:
-        g = ChunkGrid.from_rectilinear([[10, 20, 30], [50, 50]], array_shape=(60, 100))
-        d = serialize_chunk_grid(g, "rectilinear")
-        json_str = json.dumps(d)
-        d2 = json.loads(json_str)
-        g2 = parse_chunk_grid(d2, (60, 100))
-        assert g2.grid_shape == (3, 2)
-
-    def test_bare_int_roundtrip(self) -> None:
-        """Bare-integer shorthand in chunk_shapes round-trips as bare int, not [int]."""
-        data: dict[str, Any] = {
-            "name": "rectilinear",
-            "configuration": {"kind": "inline", "chunk_shapes": [10, [20, 30]]},
-        }
-        meta = RectilinearChunkGrid.from_dict(data)  # type: ignore[arg-type]
-        out = meta.to_dict()
-        # Dim 0 was bare int — should stay bare int
-        assert out["configuration"]["chunk_shapes"][0] == 10
-        # Dim 1 was explicit list — should stay list
-        assert out["configuration"]["chunk_shapes"][1] == [20, 30]
-
-    def test_unknown_name_raises(self) -> None:
-        with pytest.raises(ValueError, match="Unknown chunk grid"):
-            parse_chunk_grid({"name": "hexagonal", "configuration": {}}, (10,))
-
-    def test_serialize_non_regular_as_regular_raises(self) -> None:
-        g = ChunkGrid.from_rectilinear([[10, 20, 30], [25, 25, 25, 25]], array_shape=(60, 100))
-        with pytest.raises(ValueError, match="Cannot serialize a non-regular chunk grid"):
-            serialize_chunk_grid(g, "regular")
-
-    def test_serialize_unknown_name_raises(self) -> None:
-        g = ChunkGrid.from_regular((100,), (10,))
-        with pytest.raises(ValueError, match="Unknown chunk grid name for serialization"):
-            serialize_chunk_grid(g, "hexagonal")  # type: ignore[arg-type]
-
-    def test_zero_extent_rectilinear_raises(self) -> None:
-        """Zero-extent grids cannot be serialized as rectilinear (spec requires positive edges)."""
-        grid = ChunkGrid.from_regular((0,), (10,))
-        with pytest.raises(ValueError, match="zero-extent"):
-            serialize_chunk_grid(grid, "rectilinear")
-
-
-class TestSpecCompliance:
-    """Tests for compliance with the rectilinear chunk grid extension spec
-    (zarr-extensions PR #25)."""
-
-    def test_kind_inline_required_on_deserialize(self) -> None:
-        """Deserialization requires kind: 'inline'."""
-        data: dict[str, Any] = {
-            "name": "rectilinear",
-            "configuration": {"chunk_shapes": [[10, 20], [15, 15]]},
-        }
-        with pytest.raises(ValueError, match="requires a 'kind' field"):
-            parse_chunk_grid(data, (30, 30))
-
-    def test_kind_unknown_rejected(self) -> None:
-        data: dict[str, Any] = {
-            "name": "rectilinear",
-            "configuration": {"kind": "reference", "chunk_shapes": [[10, 20], [15, 15]]},
-        }
-        with pytest.raises(ValueError, match="Unsupported rectilinear chunk grid kind"):
-            parse_chunk_grid(data, (30, 30))
-
-    def test_kind_inline_in_serialized_output(self) -> None:
-        """Serialization includes kind: 'inline'."""
-        g = ChunkGrid.from_rectilinear([[10, 20, 30], [25, 25]], array_shape=(60, 50))
-        d = serialize_chunk_grid(g, "rectilinear")
-        config = d["configuration"]
-        assert isinstance(config, dict)
-        assert config["kind"] == "inline"
-
-    def test_integer_shorthand_per_dimension(self) -> None:
-        """A bare integer in chunk_shapes means repeat until >= extent."""
-        data: dict[str, Any] = {
-            "name": "rectilinear",
-            "configuration": {"kind": "inline", "chunk_shapes": [4, [1, 2, 3]]},
-        }
-        g = parse_chunk_grid(data, (6, 6))
-        # 4 repeated: ceildiv(6, 4) = 2 → [4, 4]
-        assert _edges(g, 0) == (4, 4)
-        assert _edges(g, 1) == (1, 2, 3)
-
-    def test_mixed_rle_and_bare_integers(self) -> None:
-        """An array can mix bare integers and [value, count] RLE pairs."""
-        data: dict[str, Any] = {
-            "name": "rectilinear",
-            "configuration": {"kind": "inline", "chunk_shapes": [[[1, 3], 3]]},
-        }
-        # [[1, 3], 3] → [1, 1, 1, 3] → sum = 6
-        g = parse_chunk_grid(data, (6,))
-        assert _edges(g, 0) == (1, 1, 1, 3)
-
-    def test_overflow_chunks_allowed(self) -> None:
-        """Edge sum >= extent is valid (overflow chunks permitted)."""
-        data: dict[str, Any] = {
-            "name": "rectilinear",
-            "configuration": {"kind": "inline", "chunk_shapes": [[4, 4, 4]]},
-        }
-        # sum = 12 > extent = 6 — allowed per spec
-        g = parse_chunk_grid(data, (6,))
-        assert _edges(g, 0) == (4, 4, 4)
-
-    def test_spec_example(self) -> None:
-        """The full example from the spec README."""
-        data: dict[str, Any] = {
-            "name": "rectilinear",
-            "configuration": {
-                "kind": "inline",
-                "chunk_shapes": [
-                    4,  # integer shorthand → [4, 4]
-                    [1, 2, 3],  # explicit list
-                    [[4, 2]],  # pure RLE → [4, 4]
-                    [[1, 3], 3],  # mixed RLE + bare → [1, 1, 1, 3]
-                    [4, 4, 4],  # explicit list with overflow
-                ],
-            },
-        }
-        g = parse_chunk_grid(data, (6, 6, 6, 6, 6))
-        assert _edges(g, 0) == (4, 4)
-        assert _edges(g, 1) == (1, 2, 3)
-        assert _edges(g, 2) == (4, 4)
-        assert _edges(g, 3) == (1, 1, 1, 3)
-        assert _edges(g, 4) == (4, 4, 4)
-
-
-class TestParseChunkGridValidation:
-    def test_varying_extent_mismatch_raises(self) -> None:
-        from zarr.core.chunk_grids import parse_chunk_grid
-
-        g = ChunkGrid.from_rectilinear([[10, 20, 30], [50, 50]], array_shape=(60, 100))
-        # VaryingDimension extent is 60, but array_shape says 100
-        with pytest.raises(ValueError, match="extent"):
-            parse_chunk_grid(g, (100, 100))
-
-    def test_varying_extent_match_ok(self) -> None:
-        from zarr.core.chunk_grids import parse_chunk_grid
-
-        g = ChunkGrid.from_rectilinear([[10, 20, 30], [50, 50]], array_shape=(60, 100))
-        # Matching extents should work fine
-        g2 = parse_chunk_grid(g, (60, 100))
-        assert g2.dimensions[0].extent == 60
-
-    def test_rectilinear_extent_mismatch_raises(self) -> None:
-        """sum(edges) must match the array shape for each dimension."""
-        data: dict[str, Any] = {
-            "name": "rectilinear",
-            "configuration": {"kind": "inline", "chunk_shapes": [[10, 20, 30], [25, 25]]},
-        }
-        # sum([10,20,30])=60, sum([25,25])=50 — array shape (100, 50) mismatches dim 0
-        with pytest.raises(ValueError, match="sum to 60 but array shape extent is 100"):
-            parse_chunk_grid(data, (100, 50))
-
-    def test_rectilinear_extent_mismatch_second_dim(self) -> None:
-        data: dict[str, Any] = {
-            "name": "rectilinear",
-            "configuration": {"kind": "inline", "chunk_shapes": [[50, 50], [10, 20]]},
-        }
-        # dim 0 OK (100), dim 1: sum([10,20])=30 != 50
-        with pytest.raises(ValueError, match="dimension 1 sum to 30 but array shape extent is 50"):
-            parse_chunk_grid(data, (100, 50))
-
-    def test_rectilinear_extent_match_passes(self) -> None:
-        data: dict[str, Any] = {
-            "name": "rectilinear",
-            "configuration": {"kind": "inline", "chunk_shapes": [[10, 20, 30], [25, 25]]},
-        }
-        g = parse_chunk_grid(data, (60, 50))
-        assert g.grid_shape == (3, 2)
-
-    def test_rectilinear_ndim_mismatch_raises(self) -> None:
-        data: dict[str, Any] = {
-            "name": "rectilinear",
-            "configuration": {"kind": "inline", "chunk_shapes": [[10, 20], [25, 25]]},
-        }
-        with pytest.raises(ValueError, match="2 dimensions but array shape has 3"):
-            parse_chunk_grid(data, (30, 50, 100))
-
-    def test_rectilinear_rle_extent_validated(self) -> None:
-        """RLE-encoded edges are expanded before validation."""
-        data: dict[str, Any] = {
-            "name": "rectilinear",
-            "configuration": {"kind": "inline", "chunk_shapes": [[[10, 5]], [[25, 2]]]},
-        }
-        # sum = 50 and 50 — match (50, 50)
-        g = parse_chunk_grid(data, (50, 50))
-        assert g.grid_shape == (5, 2)
-        # mismatch
-        with pytest.raises(ValueError, match="sum to 50 but array shape extent is 100"):
-            parse_chunk_grid(data, (100, 50))
-
-    def test_varying_dimension_extent_mismatch_on_chunkgrid_input(self) -> None:
-        """When passing a ChunkGrid directly, VaryingDimension extent is validated.
-
-        After resize, extent >= array_shape is allowed (last chunk extends past
-        boundary). But extent < array_shape is still an error.
-        """
-        g = ChunkGrid.from_rectilinear([[10, 20, 30], [25, 25]], array_shape=(60, 50))
-        with pytest.raises(ValueError, match="less than"):
-            parse_chunk_grid(g, (100, 50))
-
-
-class TestRectilinearRoundTripPreservesCodecShape:
-    def test_boundary_chunk_codec_size_preserved(self) -> None:
-        """Round-tripping through rectilinear should not change codec buffer sizes."""
-        grid = ChunkGrid.from_regular((95,), (10,))
-        original_codec_size = grid.dimensions[0].chunk_size(9)
-        assert original_codec_size == 10
-
-        serialized = serialize_chunk_grid(grid, "rectilinear")
-        parsed = parse_chunk_grid(serialized, (95,))
-
-        roundtripped_codec_size = parsed.dimensions[0].chunk_size(9)
-        assert roundtripped_codec_size == original_codec_size, (
-            f"codec buffer changed from {original_codec_size} to "
-            f"{roundtripped_codec_size} after round-trip"
+def test_chunk_grid_rectilinear_uniform_dim_is_fixed() -> None:
+    """A rectilinear grid with all-same sizes in one dim stores it as Fixed."""
+    g = ChunkGrid.from_sizes((60, 100), [[10, 20, 30], [25, 25, 25, 25]])
+    assert isinstance(g.dimensions[0], VaryingDimension)
+    assert isinstance(g.dimensions[1], FixedDimension)
+
+
+# ---------------------------------------------------------------------------
+# ChunkGrid query tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("shape", "chunks", "expected_grid_shape"),
+    [
+        ((100, 200), (10, 20), (10, 10)),
+        ((95, 200), (10, 20), (10, 10)),
+        ((60, 100), [[10, 20, 30], [25, 25, 25, 25]], (3, 4)),
+    ],
+    ids=["regular", "regular-boundary", "rectilinear"],
+)
+def test_chunk_grid_shape(
+    shape: tuple[int, ...],
+    chunks: Any,
+    expected_grid_shape: tuple[int, ...],
+) -> None:
+    """ChunkGrid.grid_shape returns the expected number of chunks per dimension"""
+    g = ChunkGrid.from_sizes(shape, chunks)
+    assert g.grid_shape == expected_grid_shape
+
+
+@pytest.mark.parametrize(
+    (
+        "array_shape",
+        "chunk_sizes",
+        "coords",
+        "expected_shape",
+        "expected_codec_shape",
+        "expected_boundary",
+    ),
+    [
+        # regular interior
+        ((100, 200), (10, 20), (0, 0), (10, 20), (10, 20), False),
+        # regular boundary
+        ((95, 200), (10, 20), (9, 0), (5, 20), (10, 20), True),
+        # rectilinear
+        ((60, 100), [[10, 20, 30], [25, 25, 25, 25]], (0, 0), (10, 25), (10, 25), False),
+        ((60, 100), [[10, 20, 30], [25, 25, 25, 25]], (1, 0), (20, 25), (20, 25), False),
+        ((60, 100), [[10, 20, 30], [25, 25, 25, 25]], (2, 3), (30, 25), (30, 25), False),
+    ],
+    ids=["regular", "regular-boundary", "rectilinear-0,0", "rectilinear-1,0", "rectilinear-2,3"],
+)
+def test_chunk_grid_getitem(
+    array_shape: tuple[int, ...],
+    chunk_sizes: Any,
+    coords: tuple[int, ...],
+    expected_shape: tuple[int, ...],
+    expected_codec_shape: tuple[int, ...],
+    expected_boundary: bool,
+) -> None:
+    """ChunkGrid.__getitem__ returns a ChunkSpec with correct shape, codec_shape, and boundary flag"""
+    g = ChunkGrid.from_sizes(array_shape, chunk_sizes)
+    spec = g[coords]
+    assert spec is not None
+    assert spec.shape == expected_shape
+    assert spec.codec_shape == expected_codec_shape
+    assert spec.is_boundary == expected_boundary
+
+
+@pytest.mark.parametrize(
+    ("array_shape", "chunk_sizes", "coords"),
+    [
+        ((100, 200), (10, 20), (99, 0)),
+        ((60, 100), [[10, 20, 30], [25, 25, 25, 25]], (3, 0)),
+    ],
+    ids=["regular-oob", "rectilinear-oob"],
+)
+def test_chunk_grid_getitem_oob(
+    array_shape: tuple[int, ...], chunk_sizes: Any, coords: tuple[int, ...]
+) -> None:
+    """Out-of-bounds chunk coordinates return None"""
+    g = ChunkGrid.from_sizes(array_shape, chunk_sizes)
+    assert g[coords] is None
+
+
+def test_chunk_grid_getitem_slices() -> None:
+    """ChunkSpec.slices reflect the correct start/stop for a rectilinear chunk"""
+    g = ChunkGrid.from_sizes((60, 100), [[10, 20, 30], [25, 25, 25, 25]])
+    spec = g[(1, 2)]
+    assert spec is not None
+    assert spec.slices == (slice(10, 30, 1), slice(50, 75, 1))
+
+
+# -- all_chunk_coords tests --
+
+
+@pytest.mark.parametrize(
+    ("array_shape", "chunk_sizes", "origin", "selection_shape", "expected_coords"),
+    [
+        # rectilinear grid
+        (
+            (60, 100),
+            [[10, 20, 30], [50, 50]],
+            None,
+            None,
+            [(0, 0), (0, 1), (1, 0), (1, 1), (2, 0), (2, 1)],
+        ),
+        ((60, 100), [[10, 20, 30], [50, 50]], (1, 0), None, [(1, 0), (1, 1), (2, 0), (2, 1)]),
+        ((60, 100), [[10, 20, 30], [50, 50]], None, (2, 1), [(0, 0), (1, 0)]),
+        ((60, 100), [[10, 20, 30], [50, 50]], (1, 1), (2, 1), [(1, 1), (2, 1)]),
+        # regular grid
+        ((30, 40), (10, 20), (2, 1), None, [(2, 1)]),
+        ((30, 40), (10, 20), None, (0, 0), []),
+        ((60, 80), (20, 20), (0, 2), (3, 1), [(0, 2), (1, 2), (2, 2)]),
+    ],
+    ids=[
+        "all",
+        "with-origin",
+        "with-sel-shape",
+        "origin+sel",
+        "last-chunk",
+        "zero-sel",
+        "single-dim",
+    ],
+)
+def test_all_chunk_coords(
+    array_shape: tuple[int, ...],
+    chunk_sizes: Any,
+    origin: tuple[int, ...] | None,
+    selection_shape: tuple[int, ...] | None,
+    expected_coords: list[tuple[int, ...]],
+) -> None:
+    """all_chunk_coords yields the expected coordinates with optional origin and selection_shape"""
+    g = ChunkGrid.from_sizes(array_shape, chunk_sizes)
+    kwargs: dict[str, Any] = {}
+    if origin is not None:
+        kwargs["origin"] = origin
+    if selection_shape is not None:
+        kwargs["selection_shape"] = selection_shape
+    assert list(g.all_chunk_coords(**kwargs)) == expected_coords
+
+
+def test_chunk_grid_get_nchunks() -> None:
+    """get_nchunks returns the total number of chunks across all dimensions"""
+    g = ChunkGrid.from_sizes((60, 100), [[10, 20, 30], [50, 50]])
+    assert g.get_nchunks() == 6
+
+
+def test_chunk_grid_iter() -> None:
+    """Iterating a ChunkGrid yields the correct number of ChunkSpec objects"""
+    g = ChunkGrid.from_sizes((30, 40), (10, 20))
+    specs = list(g)
+    assert len(specs) == 6
+    assert all(isinstance(s, ChunkSpec) for s in specs)
+
+
+# ---------------------------------------------------------------------------
+# RLE tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("compressed", "expected"),
+    [
+        ([[10, 3]], [10, 10, 10]),
+        ([[10, 2], [20, 1]], [10, 10, 20]),
+    ],
+)
+def test_rle_expand(compressed: list[Any], expected: list[int]) -> None:
+    """RLE-encoded edges expand correctly"""
+    assert expand_rle(compressed) == expected
+
+
+@pytest.mark.parametrize(
+    ("original", "expected"),
+    [
+        ([10, 10, 10], [[10, 3]]),
+        ([10, 10, 20], [[10, 2], 20]),
+        ([5], [5]),
+        ([10, 20, 30], [10, 20, 30]),
+    ],
+)
+def test_rle_compress(original: list[int], expected: list[Any]) -> None:
+    """compress_rle produces the expected RLE encoding for various input sequences"""
+    assert compress_rle(original) == expected
+
+
+def test_rle_roundtrip() -> None:
+    """compress_rle followed by expand_rle recovers the original sequence"""
+    original = [10, 10, 10, 20, 20, 30]
+    compressed = compress_rle(original)
+    assert expand_rle(compressed) == original
+
+
+@pytest.mark.parametrize(
+    ("rle_input", "match"),
+    [
+        ([0], "Chunk edge length must be >= 1"),
+        ([-5], "Chunk edge length must be >= 1"),
+        ([[0, 3]], "Chunk edge length must be >= 1"),
+        ([[-10, 2]], "Chunk edge length must be >= 1"),
+        ([[5, 0]], "RLE repeat count must be >= 1"),
+        ([[5, -1]], "RLE repeat count must be >= 1"),
+    ],
+    ids=[
+        "zero-edge",
+        "negative-edge",
+        "zero-rle-size",
+        "negative-rle-size",
+        "zero-rle-count",
+        "negative-rle-count",
+    ],
+)
+def test_rle_expand_rejects_invalid(rle_input: list[Any], match: str) -> None:
+    """expand_rle raises ValueError for zero/negative edge lengths or repeat counts"""
+    with pytest.raises(ValueError, match=match):
+        expand_rle(rle_input)
+
+
+# -- expand_rle handles JSON floats --
+
+
+def test_expand_rle_bare_integer_floats_accepted() -> None:
+    """JSON parsers may emit 10.0 for the integer 10; expand_rle should handle it."""
+    result = expand_rle([10.0, 20.0])  # type: ignore[list-item]
+    assert result == [10, 20]
+
+
+def test_expand_rle_pair_with_float_count() -> None:
+    """expand_rle accepts float repeat counts that are integer-valued"""
+    result = expand_rle([[10, 3.0]])  # type: ignore[list-item]
+    assert result == [10, 10, 10]
+
+
+# ---------------------------------------------------------------------------
+# _decode_dim_spec tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("spec", "array_extent", "expected"),
+    [
+        (10, 25, [10, 10, 10]),
+        (5, 10, [5, 5]),
+        ([10, 20, 30], None, [10, 20, 30]),
+        ([], None, []),
+        ([[5, 3], 10], None, [5, 5, 5, 10]),
+    ],
+    ids=["bare-int", "bare-int-exact", "explicit-list", "empty-list", "list-with-rle"],
+)
+def test_decode_dim_spec(spec: Any, array_extent: int | None, expected: list[int]) -> None:
+    """_decode_dim_spec correctly interprets bare ints, explicit lists, and RLE-encoded specs"""
+    assert _decode_dim_spec(spec, array_extent=array_extent) == expected
+
+
+@pytest.mark.parametrize(
+    ("spec", "array_extent", "match"),
+    [
+        (10, None, "requires array shape"),
+        (0, 10, "must be > 0"),
+        (-5, 10, "must be > 0"),
+        (10.0, 10, "Invalid chunk_shapes entry"),
+        ("auto", 10, "Invalid chunk_shapes entry"),
+        (None, 10, "Invalid chunk_shapes entry"),
+    ],
+    ids=["no-extent", "zero", "negative", "float", "string", "none"],
+)
+def test_decode_dim_spec_errors(spec: Any, array_extent: int | None, match: str) -> None:
+    """_decode_dim_spec raises ValueError for invalid specs like missing extent or bad types"""
+    with pytest.raises(ValueError, match=match):
+        _decode_dim_spec(spec, array_extent=array_extent)
+
+
+# ---------------------------------------------------------------------------
+# _is_rectilinear_chunks tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ([[10, 20], [5, 5]], True),
+        (((10, 20), (5, 5)), True),
+        ((10, 20), False),
+        ([10, 20], False),
+        (10, False),
+        ("auto", False),
+        ([], False),
+        ([[]], True),
+        (ChunkGrid.from_sizes((10,), (5,)), False),
+        (None, False),
+        (3.14, False),
+    ],
+    ids=[
+        "nested-lists",
+        "nested-tuples",
+        "flat-tuple",
+        "flat-list",
+        "single-int",
+        "string",
+        "empty-list",
+        "empty-nested-list",
+        "chunk-grid-instance",
+        "none",
+        "float",
+    ],
+)
+def test_is_rectilinear_chunks(value: Any, expected: bool) -> None:
+    """_is_rectilinear_chunks correctly identifies nested sequences as rectilinear"""
+    assert _is_rectilinear_chunks(value) is expected
+
+
+# ---------------------------------------------------------------------------
+# Serialization tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("array_shape", "chunk_sizes", "expected_name", "expected_grid_shape"),
+    [
+        ((100, 200), (10, 20), "regular", (10, 10)),
+        ((60, 100), [[10, 20, 30], [25, 25, 25, 25]], "rectilinear", (3, 4)),
+    ],
+    ids=["regular", "rectilinear"],
+)
+def test_serialization_roundtrip(
+    array_shape: tuple[int, ...],
+    chunk_sizes: Any,
+    expected_name: str,
+    expected_grid_shape: tuple[int, ...],
+) -> None:
+    """ChunkGrid survives serialize-then-parse round-trip with correct name and grid_shape"""
+    g = ChunkGrid.from_sizes(array_shape, chunk_sizes)
+    d = _serialize_via_dto(g)
+    assert d["name"] == expected_name
+    meta = parse_chunk_grid_metadata(d)
+    if isinstance(meta, RegularChunkGridMeta):
+        g2 = ChunkGrid.from_sizes(array_shape, tuple(meta.chunk_shape))
+    else:
+        g2 = ChunkGrid.from_sizes(array_shape, meta.chunk_shapes)
+    assert g2.grid_shape == expected_grid_shape
+
+
+def test_serialization_rectilinear_rle() -> None:
+    """A grid with all uniform edges serializes as regular."""
+    g = ChunkGrid.from_sizes((1000, 100), [[100] * 10, [25, 25, 25, 25]])
+    d = _serialize_via_dto(g)
+    assert d["name"] == "regular"
+
+
+def test_serialization_rectilinear_uniform_stays_regular() -> None:
+    """A grid with all uniform edges serializes as regular via DTO."""
+    g = ChunkGrid.from_sizes((1000, 100), [[100] * 10, [25, 25, 25, 25]])
+    d = _serialize_via_dto(g)
+    # All-uniform edges collapse to regular
+    assert d["name"] == "regular"
+
+
+def test_serialization_rectilinear_rle_with_varying() -> None:
+    """Rectilinear grid with repeated edges serializes using RLE compression"""
+    g = ChunkGrid.from_sizes((350, 100), [[100, 100, 100, 50], [25, 25, 25, 25]])
+    d = _serialize_via_dto(g)
+    assert d["name"] == "rectilinear"
+    config = d["configuration"]
+    assert isinstance(config, dict)
+    chunk_shapes = config["chunk_shapes"]
+    assert chunk_shapes[0] == [[100, 3], 50]
+
+
+def test_serialization_bare_int_roundtrip() -> None:
+    """Bare-integer shorthand in chunk_shapes round-trips as bare int, not [int]."""
+    data: dict[str, Any] = {
+        "name": "rectilinear",
+        "configuration": {"kind": "inline", "chunk_shapes": [10, [20, 30]]},
+    }
+    meta = RectilinearChunkGrid.from_dict(data)  # type: ignore[arg-type]
+    out = meta.to_dict()
+    assert out["configuration"]["chunk_shapes"][0] == 10
+    assert out["configuration"]["chunk_shapes"][1] == [20, 30]
+
+
+def test_serialization_error_non_regular_chunk_shape() -> None:
+    """Accessing chunk_shape on a non-regular grid raises ValueError."""
+    grid = ChunkGrid.from_sizes((60, 100), [[10, 20, 30], [25, 25, 25, 25]])
+    with pytest.raises(ValueError, match="only available for regular"):
+        grid.chunk_shape  # noqa: B018
+
+
+def test_serialization_error_zero_extent_rectilinear() -> None:
+    """RectilinearChunkGrid rejects empty edge tuples."""
+    with pytest.raises(ValueError, match="has no chunk edges"):
+        RectilinearChunkGrid(chunk_shapes=((),))
+
+
+def test_serialization_unknown_name_parse() -> None:
+    """Parsing metadata with an unknown chunk grid name raises ValueError"""
+    with pytest.raises(ValueError, match="Unknown chunk grid"):
+        parse_chunk_grid_metadata({"name": "hexagonal", "configuration": {}})
+
+
+# ---------------------------------------------------------------------------
+# Spec compliance tests
+# ---------------------------------------------------------------------------
+
+
+def test_spec_kind_inline_required_on_deserialize() -> None:
+    """Deserialization requires kind: 'inline'."""
+    data: dict[str, Any] = {
+        "name": "rectilinear",
+        "configuration": {"chunk_shapes": [[10, 20], [15, 15]]},
+    }
+    with pytest.raises(ValueError, match="requires a 'kind' field"):
+        parse_chunk_grid_metadata(data)
+
+
+def test_spec_kind_unknown_rejected() -> None:
+    """Unsupported rectilinear chunk grid kind raises ValueError on parse"""
+    data: dict[str, Any] = {
+        "name": "rectilinear",
+        "configuration": {"kind": "reference", "chunk_shapes": [[10, 20], [15, 15]]},
+    }
+    with pytest.raises(ValueError, match="Unsupported rectilinear chunk grid kind"):
+        parse_chunk_grid_metadata(data)
+
+
+def test_spec_kind_inline_in_serialized_output() -> None:
+    """Serialization includes kind: 'inline'."""
+    g = ChunkGrid.from_sizes((60, 50), [[10, 20, 30], [25, 25]])
+    d = _serialize_via_dto(g)
+    config = d["configuration"]
+    assert isinstance(config, dict)
+    assert config["kind"] == "inline"
+
+
+def test_spec_integer_shorthand_per_dimension() -> None:
+    """A bare integer in chunk_shapes means repeat until >= extent."""
+    data: dict[str, Any] = {
+        "name": "rectilinear",
+        "configuration": {"kind": "inline", "chunk_shapes": [4, [1, 2, 3]]},
+    }
+    meta = parse_chunk_grid_metadata(data)
+    g = ChunkGrid.from_sizes((6, 6), meta.chunk_shapes)
+    assert _edges(g, 0) == (4, 4)
+    assert _edges(g, 1) == (1, 2, 3)
+
+
+def test_spec_mixed_rle_and_bare_integers() -> None:
+    """An array can mix bare integers and [value, count] RLE pairs."""
+    data: dict[str, Any] = {
+        "name": "rectilinear",
+        "configuration": {"kind": "inline", "chunk_shapes": [[[1, 3], 3]]},
+    }
+    meta = parse_chunk_grid_metadata(data)
+    g = ChunkGrid.from_sizes((6,), meta.chunk_shapes)
+    assert _edges(g, 0) == (1, 1, 1, 3)
+
+
+def test_spec_overflow_chunks_allowed() -> None:
+    """Edge sum >= extent is valid (overflow chunks permitted)."""
+    data: dict[str, Any] = {
+        "name": "rectilinear",
+        "configuration": {"kind": "inline", "chunk_shapes": [[4, 4, 4]]},
+    }
+    meta = parse_chunk_grid_metadata(data)
+    g = ChunkGrid.from_sizes((6,), meta.chunk_shapes)
+    assert _edges(g, 0) == (4, 4, 4)
+
+
+def test_spec_example() -> None:
+    """The full example from the spec README."""
+    data: dict[str, Any] = {
+        "name": "rectilinear",
+        "configuration": {
+            "kind": "inline",
+            "chunk_shapes": [
+                4,
+                [1, 2, 3],
+                [[4, 2]],
+                [[1, 3], 3],
+                [4, 4, 4],
+            ],
+        },
+    }
+    meta = parse_chunk_grid_metadata(data)
+    g = ChunkGrid.from_sizes((6, 6, 6, 6, 6), meta.chunk_shapes)
+    assert _edges(g, 0) == (4, 4)
+    assert _edges(g, 1) == (1, 2, 3)
+    assert _edges(g, 2) == (4, 4)
+    assert _edges(g, 3) == (1, 1, 1, 3)
+    assert _edges(g, 4) == (4, 4, 4)
+
+
+# ---------------------------------------------------------------------------
+# parse_chunk_grid validation tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_chunk_grid_varying_extent_mismatch_raises() -> None:
+    """Reconstructing a ChunkGrid with mismatched extents raises ValueError"""
+    g = ChunkGrid.from_sizes((60, 100), [[10, 20, 30], [50, 50]])
+    with pytest.raises(ValueError, match="extent"):
+        ChunkGrid(
+            dimensions=tuple(
+                dim.with_extent(ext) for dim, ext in zip(g.dimensions, (100, 100), strict=True)
+            )
         )
 
-    def test_single_chunk_boundary_codec_size_preserved(self) -> None:
-        """shape=7, chunk_size=10: single chunk's codec buffer should stay 10."""
-        grid = ChunkGrid.from_regular((7,), (10,))
-        assert grid.dimensions[0].chunk_size(0) == 10
 
-        serialized = serialize_chunk_grid(grid, "rectilinear")
-        parsed = parse_chunk_grid(serialized, (7,))
-
-        assert parsed.dimensions[0].chunk_size(0) == 10
-
-
-class TestRectilinearIndexing:
-    """Test that the indexing pipeline works with VaryingDimension."""
-
-    def test_basic_indexer_rectilinear(self) -> None:
-        from zarr.core.indexing import BasicIndexer
-
-        g = ChunkGrid.from_rectilinear([[10, 20, 30], [50, 50]], array_shape=(60, 100))
-        indexer = BasicIndexer(
-            selection=(slice(None), slice(None)),
-            shape=(60, 100),
-            chunk_grid=g,
+def test_parse_chunk_grid_varying_extent_match_ok() -> None:
+    """Reconstructing a ChunkGrid with matching extents succeeds"""
+    g = ChunkGrid.from_sizes((60, 100), [[10, 20, 30], [50, 50]])
+    g2 = ChunkGrid(
+        dimensions=tuple(
+            dim.with_extent(ext) for dim, ext in zip(g.dimensions, (60, 100), strict=True)
         )
-        projections = list(indexer)
-        assert len(projections) == 6
+    )
+    assert g2.dimensions[0].extent == 60
 
-        p0 = projections[0]
-        assert p0.chunk_coords == (0, 0)
-        assert p0.chunk_selection == (slice(0, 10, 1), slice(0, 50, 1))
 
-        p1 = projections[2]
-        assert p1.chunk_coords == (1, 0)
-        assert p1.chunk_selection == (slice(0, 20, 1), slice(0, 50, 1))
+@pytest.mark.parametrize(
+    ("chunk_shapes", "array_shape", "match"),
+    [
+        ([[10, 20, 30], [25, 25]], (100, 50), "extent 100 exceeds sum of edges 60"),
+        ([[50, 50], [10, 20]], (100, 50), "extent 50 exceeds sum of edges 30"),
+    ],
+    ids=["first-dim-mismatch", "second-dim-mismatch"],
+)
+def test_parse_chunk_grid_rectilinear_extent_mismatch_raises(
+    chunk_shapes: list[list[int]], array_shape: tuple[int, ...], match: str
+) -> None:
+    """Rectilinear grid raises ValueError when array extent exceeds sum of edges"""
+    data: dict[str, Any] = {
+        "name": "rectilinear",
+        "configuration": {"kind": "inline", "chunk_shapes": chunk_shapes},
+    }
+    meta = parse_chunk_grid_metadata(data)
+    with pytest.raises(ValueError, match=match):
+        ChunkGrid.from_sizes(array_shape, meta.chunk_shapes)
 
-    def test_basic_indexer_int_selection(self) -> None:
-        from zarr.core.indexing import BasicIndexer
 
-        g = ChunkGrid.from_rectilinear([[10, 20, 30], [50, 50]], array_shape=(60, 100))
-        indexer = BasicIndexer(
-            selection=(15, slice(None)),
-            shape=(60, 100),
-            chunk_grid=g,
+def test_parse_chunk_grid_rectilinear_extent_match_passes() -> None:
+    """Rectilinear grid with matching extents parses and builds successfully"""
+    data: dict[str, Any] = {
+        "name": "rectilinear",
+        "configuration": {"kind": "inline", "chunk_shapes": [[10, 20, 30], [25, 25]]},
+    }
+    meta = parse_chunk_grid_metadata(data)
+    g = ChunkGrid.from_sizes((60, 50), meta.chunk_shapes)
+    assert g.grid_shape == (3, 2)
+
+
+def test_parse_chunk_grid_rectilinear_ndim_mismatch_raises() -> None:
+    """Mismatched ndim between array shape and chunk_sizes raises ValueError"""
+    data: dict[str, Any] = {
+        "name": "rectilinear",
+        "configuration": {"kind": "inline", "chunk_shapes": [[10, 20], [25, 25]]},
+    }
+    meta = parse_chunk_grid_metadata(data)
+    with pytest.raises(ValueError, match="3 dimensions but chunk_sizes has 2"):
+        ChunkGrid.from_sizes((30, 50, 100), meta.chunk_shapes)
+
+
+def test_parse_chunk_grid_rectilinear_rle_extent_validated() -> None:
+    """RLE-encoded edges are expanded before validation."""
+    data: dict[str, Any] = {
+        "name": "rectilinear",
+        "configuration": {"kind": "inline", "chunk_shapes": [[[10, 5]], [[25, 2]]]},
+    }
+    meta = parse_chunk_grid_metadata(data)
+    g = ChunkGrid.from_sizes((50, 50), meta.chunk_shapes)
+    assert g.grid_shape == (5, 2)
+    with pytest.raises(ValueError, match="extent 100 exceeds sum of edges 50"):
+        ChunkGrid.from_sizes((100, 50), meta.chunk_shapes)
+
+
+def test_parse_chunk_grid_varying_dimension_extent_mismatch_on_chunkgrid_input() -> None:
+    """ChunkGrid constructor rejects VaryingDimension with extent exceeding sum of edges"""
+    g = ChunkGrid.from_sizes((60, 50), [[10, 20, 30], [25, 25]])
+    with pytest.raises(ValueError, match="less than"):
+        ChunkGrid(
+            dimensions=tuple(
+                dim.with_extent(ext) for dim, ext in zip(g.dimensions, (100, 50), strict=True)
+            )
         )
-        projections = list(indexer)
-        assert len(projections) == 2
-        assert projections[0].chunk_coords == (1, 0)
-        assert projections[0].chunk_selection == (5, slice(0, 50, 1))
-
-    def test_basic_indexer_slice_subset(self) -> None:
-        from zarr.core.indexing import BasicIndexer
-
-        g = ChunkGrid.from_rectilinear([[10, 20, 30], [50, 50]], array_shape=(60, 100))
-        indexer = BasicIndexer(
-            selection=(slice(5, 35), slice(0, 50)),
-            shape=(60, 100),
-            chunk_grid=g,
-        )
-        projections = list(indexer)
-        chunk_coords_dim0 = sorted({p.chunk_coords[0] for p in projections})
-        assert chunk_coords_dim0 == [0, 1, 2]
-
-    def test_orthogonal_indexer_rectilinear(self) -> None:
-        from zarr.core.indexing import OrthogonalIndexer
-
-        g = ChunkGrid.from_rectilinear([[10, 20, 30], [50, 50]], array_shape=(60, 100))
-        indexer = OrthogonalIndexer(
-            selection=(slice(None), slice(None)),
-            shape=(60, 100),
-            chunk_grid=g,
-        )
-        projections = list(indexer)
-        assert len(projections) == 6
-
-    def test_oob_block_raises_bounds_check_error(self) -> None:
-        """Out-of-bounds block index should raise BoundsCheckError, not IndexError."""
-        store = MemoryStore()
-        a = zarr.create_array(store, shape=(30,), chunks=[[10, 20]], dtype="int32")
-        with pytest.raises(BoundsCheckError):
-            a.get_block_selection((2,))
 
 
-class TestEndToEnd:
-    """Test creating, writing, and reading arrays with rectilinear chunk grids."""
-
-    def test_create_regular_array(self, tmp_path: Path) -> None:
-        import zarr
-
-        arr = zarr.create_array(
-            store=tmp_path / "regular.zarr",
-            shape=(100, 200),
-            chunks=(10, 20),
-            dtype="float32",
-        )
-        assert arr.chunk_grid.is_regular
-        assert arr.chunks == (10, 20)
-
-    def test_create_rectilinear_array(self, tmp_path: Path) -> None:
-        """Create an array with a rectilinear chunk grid via metadata."""
-        from zarr.core.metadata.v3 import ArrayV3Metadata, RectilinearChunkGrid
-
-        arr = zarr.create_array(
-            store=tmp_path / "rect.zarr",
-            shape=(60, 100),
-            chunks=[[10, 20, 30], [50, 50]],
-            dtype="float32",
-        )
-        assert isinstance(arr.metadata, ArrayV3Metadata)
-        assert isinstance(arr.metadata.chunk_grid, RectilinearChunkGrid)
-        assert not arr.chunk_grid.is_regular
-        assert arr.chunk_grid.ndim == 2
-
-    def test_rectilinear_metadata_serialization(self, tmp_path: Path) -> None:
-        """Verify metadata round-trips through JSON."""
-        g = ChunkGrid.from_rectilinear([[10, 20, 30], [50, 50]], array_shape=(60, 100))
-        d = serialize_chunk_grid(g, "rectilinear")
-        g2 = parse_chunk_grid(d, (60, 100))
-        assert g2.grid_shape == g.grid_shape
-        for coord in g.all_chunk_coords():
-            orig_spec = g[coord]
-            new_spec = g2[coord]
-            assert orig_spec is not None
-            assert new_spec is not None
-            assert orig_spec.shape == new_spec.shape
-
-    def test_chunk_grid_serializes_regular(self, tmp_path: Path) -> None:
-        """Regular arrays serialize with name='regular'."""
-        from zarr.core.metadata.v3 import ArrayV3Metadata, RegularChunkGrid
-
-        arr = zarr.create_array(
-            store=tmp_path / "regular.zarr",
-            shape=(100, 200),
-            chunks=(10, 20),
-            dtype="float32",
-        )
-        assert isinstance(arr.metadata, ArrayV3Metadata)
-        assert isinstance(arr.metadata.chunk_grid, RegularChunkGrid)
-        d = arr.metadata.to_dict()
-        chunk_grid_dict = d["chunk_grid"]
-        assert isinstance(chunk_grid_dict, dict)
-        assert chunk_grid_dict["name"] == "regular"
-
-    def test_chunk_grid_serializes_rectilinear(self, tmp_path: Path) -> None:
-        """Rectilinear arrays serialize with name='rectilinear'."""
-        from zarr.core.metadata.v3 import ArrayV3Metadata, RectilinearChunkGrid
-
-        arr = zarr.create_array(
-            store=tmp_path / "rect.zarr",
-            shape=(60, 100),
-            chunks=[[10, 20, 30], [50, 50]],
-            dtype="float32",
-        )
-        assert isinstance(arr.metadata, ArrayV3Metadata)
-        assert isinstance(arr.metadata.chunk_grid, RectilinearChunkGrid)
-        d = arr.metadata.to_dict()
-        chunk_grid_dict = d["chunk_grid"]
-        assert isinstance(chunk_grid_dict, dict)
-        assert chunk_grid_dict["name"] == "rectilinear"
-
-    def test_chunk_grid_name_roundtrip_preserves_rectilinear(self, tmp_path: Path) -> None:
-        """A rectilinear grid with uniform edges stays 'rectilinear' through to_dict/from_dict."""
-        from zarr.core.metadata.v3 import ArrayV3Metadata, RectilinearChunkGrid
-
-        meta_dict: dict[str, Any] = {
-            "zarr_format": 3,
-            "node_type": "array",
-            "shape": [100, 100],
-            "chunk_grid": {
-                "name": "rectilinear",
-                "configuration": {"kind": "inline", "chunk_shapes": [[[50, 2]], [[25, 4]]]},
-            },
-            "chunk_key_encoding": {"name": "default"},
-            "data_type": "float32",
-            "fill_value": 0.0,
-            "codecs": [{"name": "bytes", "configuration": {"endian": "little"}}],
-        }
-        meta = ArrayV3Metadata.from_dict(meta_dict)
-        assert isinstance(meta.chunk_grid, RectilinearChunkGrid)
-        d = meta.to_dict()
-        chunk_grid_dict = d["chunk_grid"]
-        assert isinstance(chunk_grid_dict, dict)
-        assert chunk_grid_dict["name"] == "rectilinear"
-
-    def test_chunk_grid_name_regular_from_dict(self, tmp_path: Path) -> None:
-        """A 'regular' chunk grid name is preserved through from_dict."""
-        from zarr.core.metadata.v3 import ArrayV3Metadata, RegularChunkGrid
-
-        meta_dict: dict[str, Any] = {
-            "zarr_format": 3,
-            "node_type": "array",
-            "shape": [100, 100],
-            "chunk_grid": {
-                "name": "regular",
-                "configuration": {"chunk_shape": [50, 25]},
-            },
-            "chunk_key_encoding": {"name": "default"},
-            "data_type": "float32",
-            "fill_value": 0.0,
-            "codecs": [{"name": "bytes", "configuration": {"endian": "little"}}],
-        }
-        meta = ArrayV3Metadata.from_dict(meta_dict)
-        assert isinstance(meta.chunk_grid, RegularChunkGrid)
-        d = meta.to_dict()
-        chunk_grid_dict = d["chunk_grid"]
-        assert isinstance(chunk_grid_dict, dict)
-        assert chunk_grid_dict["name"] == "regular"
-
-    def test_get_chunk_spec_regular(self, tmp_path: Path) -> None:
-        """ChunkGrid indexing works for regular grids."""
-        grid = ChunkGrid.from_regular((100, 200), (10, 20))
-
-        spec = grid[(0, 0)]
-        assert spec is not None
-        assert spec.shape == (10, 20)
-
-        spec_boundary = grid[(9, 9)]
-        assert spec_boundary is not None
-        assert spec_boundary.shape == (10, 20)
-
-    def test_get_chunk_spec_rectilinear(self, tmp_path: Path) -> None:
-        """ChunkGrid indexing returns per-chunk shapes for rectilinear grids."""
-        grid = ChunkGrid.from_rectilinear([[10, 20, 30], [50, 50]], array_shape=(60, 100))
-
-        spec0 = grid[(0, 0)]
-        assert spec0 is not None
-        assert spec0.shape == (10, 50)
-
-        spec1 = grid[(1, 0)]
-        assert spec1 is not None
-        assert spec1.shape == (20, 50)
-
-        spec2 = grid[(2, 1)]
-        assert spec2 is not None
-        assert spec2.shape == (30, 50)
+# ---------------------------------------------------------------------------
+# Rectilinear round-trip preserves codec shape
+# ---------------------------------------------------------------------------
 
 
-class TestShardingCompat:
-    def test_sharding_accepts_rectilinear_outer_grid(self) -> None:
-        """ShardingCodec.validate should not reject rectilinear outer grids."""
-        from zarr.codecs.sharding import ShardingCodec
-        from zarr.core.dtype import Float32
-        from zarr.core.metadata.v3 import RectilinearChunkGrid
+@pytest.mark.parametrize(
+    ("shape", "chunks", "chunk_idx", "expected_codec_size"),
+    [
+        ((95,), (10,), 9, 10),
+        ((7,), (10,), 0, 10),
+    ],
+    ids=["boundary-chunk", "single-chunk-boundary"],
+)
+def test_rectilinear_roundtrip_preserves_codec_shape(
+    shape: tuple[int, ...],
+    chunks: tuple[int, ...],
+    chunk_idx: int,
+    expected_codec_size: int,
+) -> None:
+    """Serialization round-trip preserves codec_shape for boundary chunks"""
+    grid = ChunkGrid.from_sizes(shape, chunks)
+    assert grid.dimensions[0].chunk_size(chunk_idx) == expected_codec_size
+    serialized = _serialize_via_dto(grid)
+    meta = parse_chunk_grid_metadata(serialized)
+    if isinstance(meta, RegularChunkGridMeta):
+        parsed = ChunkGrid.from_sizes(shape, tuple(meta.chunk_shape))
+    else:
+        parsed = ChunkGrid.from_sizes(shape, meta.chunk_shapes)
+    assert parsed.dimensions[0].chunk_size(chunk_idx) == expected_codec_size
 
-        codec = ShardingCodec(chunk_shape=(5, 5))
-        grid_meta = RectilinearChunkGrid(chunk_shapes=((10, 20, 30), (50, 50)))
 
+# ---------------------------------------------------------------------------
+# Rectilinear indexing tests
+# ---------------------------------------------------------------------------
+
+
+def test_basic_indexer_rectilinear() -> None:
+    """BasicIndexer produces correct projections for a full-slice rectilinear selection"""
+    from zarr.core.indexing import BasicIndexer
+
+    g = ChunkGrid.from_sizes((60, 100), [[10, 20, 30], [50, 50]])
+    indexer = BasicIndexer(
+        selection=(slice(None), slice(None)),
+        shape=(60, 100),
+        chunk_grid=g,
+    )
+    projections = list(indexer)
+    assert len(projections) == 6
+
+    p0 = projections[0]
+    assert p0.chunk_coords == (0, 0)
+    assert p0.chunk_selection == (slice(0, 10, 1), slice(0, 50, 1))
+
+    p1 = projections[2]
+    assert p1.chunk_coords == (1, 0)
+    assert p1.chunk_selection == (slice(0, 20, 1), slice(0, 50, 1))
+
+
+def test_basic_indexer_int_selection() -> None:
+    """BasicIndexer with integer selection maps to the correct chunk and local offset"""
+    from zarr.core.indexing import BasicIndexer
+
+    g = ChunkGrid.from_sizes((60, 100), [[10, 20, 30], [50, 50]])
+    indexer = BasicIndexer(
+        selection=(15, slice(None)),
+        shape=(60, 100),
+        chunk_grid=g,
+    )
+    projections = list(indexer)
+    assert len(projections) == 2
+    assert projections[0].chunk_coords == (1, 0)
+    assert projections[0].chunk_selection == (5, slice(0, 50, 1))
+
+
+def test_basic_indexer_slice_subset() -> None:
+    """BasicIndexer with partial slices spans the expected chunk dimensions"""
+    from zarr.core.indexing import BasicIndexer
+
+    g = ChunkGrid.from_sizes((60, 100), [[10, 20, 30], [50, 50]])
+    indexer = BasicIndexer(
+        selection=(slice(5, 35), slice(0, 50)),
+        shape=(60, 100),
+        chunk_grid=g,
+    )
+    projections = list(indexer)
+    chunk_coords_dim0 = sorted({p.chunk_coords[0] for p in projections})
+    assert chunk_coords_dim0 == [0, 1, 2]
+
+
+def test_orthogonal_indexer_rectilinear() -> None:
+    """OrthogonalIndexer produces the expected number of projections for a rectilinear grid"""
+    from zarr.core.indexing import OrthogonalIndexer
+
+    g = ChunkGrid.from_sizes((60, 100), [[10, 20, 30], [50, 50]])
+    indexer = OrthogonalIndexer(
+        selection=(slice(None), slice(None)),
+        shape=(60, 100),
+        chunk_grid=g,
+    )
+    projections = list(indexer)
+    assert len(projections) == 6
+
+
+def test_oob_block_raises_bounds_check_error() -> None:
+    """Out-of-bounds block index should raise BoundsCheckError, not IndexError."""
+    store = MemoryStore()
+    a = zarr.create_array(store, shape=(30,), chunks=[[10, 20]], dtype="int32")
+    with pytest.raises(BoundsCheckError):
+        a.get_block_selection((2,))
+
+
+# ---------------------------------------------------------------------------
+# End-to-end tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("shape", "chunks", "expected_regular"),
+    [
+        ((100, 200), (10, 20), True),
+        ((60, 100), [[10, 20, 30], [50, 50]], False),
+    ],
+    ids=["regular", "rectilinear"],
+)
+def test_e2e_create_array(
+    tmp_path: Path, shape: tuple[int, ...], chunks: Any, expected_regular: bool
+) -> None:
+    """End-to-end array creation sets correct regularity and ndim on chunk_grid"""
+    arr = zarr.create_array(
+        store=tmp_path / "arr.zarr",
+        shape=shape,
+        chunks=chunks,
+        dtype="float32",
+    )
+    assert arr.chunk_grid.is_regular == expected_regular
+    assert arr.chunk_grid.ndim == len(shape)
+
+
+@pytest.mark.parametrize(
+    ("shape", "chunks", "grid_type_name", "grid_name"),
+    [
+        ((100, 200), (10, 20), "RegularChunkGrid", "regular"),
+        ((60, 100), [[10, 20, 30], [50, 50]], "RectilinearChunkGrid", "rectilinear"),
+    ],
+    ids=["regular", "rectilinear"],
+)
+def test_e2e_chunk_grid_serializes(
+    tmp_path: Path, shape: tuple[int, ...], chunks: Any, grid_type_name: str, grid_name: str
+) -> None:
+    """Array metadata serializes chunk_grid with the correct type and name"""
+    from zarr.core.metadata.v3 import ArrayV3Metadata, RectilinearChunkGrid, RegularChunkGrid
+
+    grid_type = RegularChunkGrid if grid_type_name == "RegularChunkGrid" else RectilinearChunkGrid
+    arr = zarr.create_array(
+        store=tmp_path / "arr.zarr",
+        shape=shape,
+        chunks=chunks,
+        dtype="float32",
+    )
+    assert isinstance(arr.metadata, ArrayV3Metadata)
+    assert isinstance(arr.metadata.chunk_grid, grid_type)
+    d = arr.metadata.to_dict()
+    chunk_grid_dict = d["chunk_grid"]
+    assert isinstance(chunk_grid_dict, dict)
+    assert chunk_grid_dict["name"] == grid_name
+
+
+def test_e2e_chunk_grid_name_roundtrip_preserves_rectilinear(tmp_path: Path) -> None:
+    """A rectilinear grid with uniform edges stays 'rectilinear' through to_dict/from_dict."""
+    from zarr.core.metadata.v3 import ArrayV3Metadata, RectilinearChunkGrid
+
+    meta_dict: dict[str, Any] = {
+        "zarr_format": 3,
+        "node_type": "array",
+        "shape": [100, 100],
+        "chunk_grid": {
+            "name": "rectilinear",
+            "configuration": {"kind": "inline", "chunk_shapes": [[[50, 2]], [[25, 4]]]},
+        },
+        "chunk_key_encoding": {"name": "default"},
+        "data_type": "float32",
+        "fill_value": 0.0,
+        "codecs": [{"name": "bytes", "configuration": {"endian": "little"}}],
+    }
+    meta = ArrayV3Metadata.from_dict(meta_dict)
+    assert isinstance(meta.chunk_grid, RectilinearChunkGrid)
+    d = meta.to_dict()
+    chunk_grid_dict = d["chunk_grid"]
+    assert isinstance(chunk_grid_dict, dict)
+    assert chunk_grid_dict["name"] == "rectilinear"
+
+
+def test_e2e_chunk_grid_name_regular_from_dict(tmp_path: Path) -> None:
+    """A 'regular' chunk grid name is preserved through from_dict."""
+    from zarr.core.metadata.v3 import ArrayV3Metadata, RegularChunkGrid
+
+    meta_dict: dict[str, Any] = {
+        "zarr_format": 3,
+        "node_type": "array",
+        "shape": [100, 100],
+        "chunk_grid": {
+            "name": "regular",
+            "configuration": {"chunk_shape": [50, 25]},
+        },
+        "chunk_key_encoding": {"name": "default"},
+        "data_type": "float32",
+        "fill_value": 0.0,
+        "codecs": [{"name": "bytes", "configuration": {"endian": "little"}}],
+    }
+    meta = ArrayV3Metadata.from_dict(meta_dict)
+    assert isinstance(meta.chunk_grid, RegularChunkGrid)
+    d = meta.to_dict()
+    chunk_grid_dict = d["chunk_grid"]
+    assert isinstance(chunk_grid_dict, dict)
+    assert chunk_grid_dict["name"] == "regular"
+
+
+# ---------------------------------------------------------------------------
+# Sharding compatibility tests
+# ---------------------------------------------------------------------------
+
+
+def test_sharding_accepts_rectilinear_outer_grid() -> None:
+    """ShardingCodec.validate should not reject rectilinear outer grids."""
+    from zarr.codecs.sharding import ShardingCodec
+    from zarr.core.dtype import Float32
+    from zarr.core.metadata.v3 import RectilinearChunkGrid
+
+    codec = ShardingCodec(chunk_shape=(5, 5))
+    grid_meta = RectilinearChunkGrid(chunk_shapes=((10, 20, 30), (50, 50)))
+
+    codec.validate(
+        shape=(60, 100),
+        dtype=Float32(),
+        chunk_grid=grid_meta,
+    )
+
+
+def test_sharding_rejects_non_divisible_rectilinear() -> None:
+    """Rectilinear shard sizes not divisible by inner chunk_shape should raise."""
+    from zarr.codecs.sharding import ShardingCodec
+    from zarr.core.dtype import Float32
+    from zarr.core.metadata.v3 import RectilinearChunkGrid
+
+    codec = ShardingCodec(chunk_shape=(5, 5))
+    grid_meta = RectilinearChunkGrid(chunk_shapes=((10, 20, 17), (50, 50)))
+
+    with pytest.raises(ValueError, match="divisible"):
         codec.validate(
-            shape=(60, 100),
+            shape=(47, 100),
             dtype=Float32(),
             chunk_grid=grid_meta,
         )
 
 
-class TestEdgeCases:
-    """Edge cases around boundary chunks, zero-size dims, direct construction,
-    and serialization round-trips."""
+def test_sharding_accepts_divisible_rectilinear() -> None:
+    """Rectilinear shard sizes all divisible by inner chunk_shape should pass."""
+    from zarr.codecs.sharding import ShardingCodec
+    from zarr.core.dtype import Float32
+    from zarr.core.metadata.v3 import RectilinearChunkGrid
 
-    # -- FixedDimension boundary (extent != size * nchunks) --
+    codec = ShardingCodec(chunk_shape=(5, 5))
+    grid_meta = RectilinearChunkGrid(chunk_shapes=((10, 20, 30), (50, 50)))
 
-    def test_fixed_dim_boundary_data_size(self) -> None:
-        """Boundary chunk's data_size is clipped to the remainder."""
-        d = FixedDimension(size=10, extent=95)
-        assert d.nchunks == 10
-        assert d.data_size(0) == 10
-        assert d.data_size(9) == 5  # 95 - 9*10 = 5
-        assert d.chunk_size(9) == 10  # codec buffer always full
+    codec.validate(
+        shape=(60, 100),
+        dtype=Float32(),
+        chunk_grid=grid_meta,
+    )
 
-    # FixedDimension.data_size does not bounds-check for performance.
-    # OOB access is tested via ChunkGrid.__getitem__.
 
-    def test_chunk_grid_boundary_getitem(self) -> None:
-        """ChunkGrid with boundary FixedDimension via direct construction."""
-        g = ChunkGrid(dimensions=(FixedDimension(10, 95), FixedDimension(20, 40)))
-        spec = g[(9, 1)]
-        assert spec is not None
-        assert spec.shape == (5, 20)  # data: (95-90, 40-20)
-        assert spec.codec_shape == (10, 20)  # codec buffers are full
-        assert spec.is_boundary
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
 
-    def test_chunk_grid_boundary_iter(self) -> None:
-        """Iterating a boundary grid yields correct boundary ChunkSpecs."""
-        g = ChunkGrid(dimensions=(FixedDimension(10, 25),))
-        specs = list(g)
-        assert len(specs) == 3
-        assert specs[0].shape == (10,)
-        assert specs[1].shape == (10,)
-        assert specs[2].shape == (5,)
-        assert specs[2].is_boundary
-        assert not specs[0].is_boundary
 
-    def test_chunk_grid_boundary_shape(self) -> None:
-        """shape property with boundary extent."""
-        g = ChunkGrid(dimensions=(FixedDimension(10, 95),))
-        assert g.grid_shape == (10,)  # ceildiv(95, 10) = 10
+def test_edge_case_chunk_grid_boundary_getitem() -> None:
+    """ChunkGrid with boundary FixedDimension via direct construction."""
+    g = ChunkGrid(dimensions=(FixedDimension(10, 95), FixedDimension(20, 40)))
+    spec = g[(9, 1)]
+    assert spec is not None
+    assert spec.shape == (5, 20)
+    assert spec.codec_shape == (10, 20)
+    assert spec.is_boundary
 
-    # -- Boundary FixedDimension in rectilinear serialization --
 
-    def test_boundary_fixed_dim_rectilinear_roundtrip(self) -> None:
-        """A rectilinear grid with a boundary FixedDimension preserves extent."""
-        g = ChunkGrid(
-            dimensions=(
-                VaryingDimension([10, 20, 30], extent=60),
-                FixedDimension(size=10, extent=95),
-            )
+def test_edge_case_chunk_grid_boundary_iter() -> None:
+    """Iterating a boundary grid yields correct boundary ChunkSpecs."""
+    g = ChunkGrid(dimensions=(FixedDimension(10, 25),))
+    specs = list(g)
+    assert len(specs) == 3
+    assert specs[0].shape == (10,)
+    assert specs[1].shape == (10,)
+    assert specs[2].shape == (5,)
+    assert specs[2].is_boundary
+    assert not specs[0].is_boundary
+
+
+def test_edge_case_chunk_grid_boundary_shape() -> None:
+    """shape property with boundary extent."""
+    g = ChunkGrid(dimensions=(FixedDimension(10, 95),))
+    assert g.grid_shape == (10,)
+
+
+# -- Boundary FixedDimension in rectilinear serialization --
+
+
+def test_edge_case_boundary_fixed_dim_rectilinear_roundtrip() -> None:
+    """A rectilinear grid with a boundary FixedDimension preserves extent."""
+    g = ChunkGrid(
+        dimensions=(
+            VaryingDimension([10, 20, 30], extent=60),
+            FixedDimension(size=10, extent=95),
         )
-        assert g.grid_shape == (3, 10)
+    )
+    assert g.grid_shape == (3, 10)
 
-        d = serialize_chunk_grid(g, "rectilinear")
-        assert d["name"] == "rectilinear"
-        # Second dim serializes as bare integer (per rectilinear spec,
-        # a bare integer repeats until sum >= extent, preserving full
-        # codec buffer size for boundary chunks).
-        config = d["configuration"]
-        assert isinstance(config, dict)
-        chunk_shapes = config["chunk_shapes"]
-        assert isinstance(chunk_shapes, list)
-        assert chunk_shapes[1] == 10  # bare integer shorthand
+    d = _serialize_via_dto(g)
+    assert d["name"] == "rectilinear"
+    config = d["configuration"]
+    assert isinstance(config, dict)
+    chunk_shapes = config["chunk_shapes"]
+    assert chunk_shapes[1] == 10  # bare integer shorthand
 
-        g2 = parse_chunk_grid(d, (60, 95))
-        assert g2.grid_shape == g.grid_shape
-        # Round-tripped grid should have correct extent
-        for coord in g.all_chunk_coords():
-            orig = g[coord]
-            new = g2[coord]
-            assert orig is not None
-            assert new is not None
-            assert orig.shape == new.shape
+    meta = parse_chunk_grid_metadata(d)
+    g2 = ChunkGrid.from_sizes((60, 95), meta.chunk_shapes)
+    assert g2.grid_shape == g.grid_shape
+    for coord in g.all_chunk_coords():
+        orig = g[coord]
+        new = g2[coord]
+        assert orig is not None
+        assert new is not None
+        assert orig.shape == new.shape
 
-    def test_exact_extent_fixed_dim_rectilinear_roundtrip(self) -> None:
-        """No boundary: extent == size * nchunks round-trips cleanly."""
-        g = ChunkGrid(
-            dimensions=(
-                VaryingDimension([10, 20], extent=30),
-                FixedDimension(size=25, extent=100),
-            )
+
+def test_edge_case_exact_extent_fixed_dim_rectilinear_roundtrip() -> None:
+    """No boundary: extent == size * nchunks round-trips cleanly."""
+    g = ChunkGrid(
+        dimensions=(
+            VaryingDimension([10, 20], extent=30),
+            FixedDimension(size=25, extent=100),
         )
-        d = serialize_chunk_grid(g, "rectilinear")
-        g2 = parse_chunk_grid(d, (30, 100))
-        assert g2.grid_shape == g.grid_shape
-        # All chunks should be uniform
-        for coord in g.all_chunk_coords():
-            orig = g[coord]
-            new = g2[coord]
-            assert orig is not None
-            assert new is not None
-            assert orig.shape == new.shape
+    )
+    d = _serialize_via_dto(g)
+    meta = parse_chunk_grid_metadata(d)
+    g2 = ChunkGrid.from_sizes((30, 100), meta.chunk_shapes)
+    assert g2.grid_shape == g.grid_shape
+    for coord in g.all_chunk_coords():
+        orig = g[coord]
+        new = g2[coord]
+        assert orig is not None
+        assert new is not None
+        assert orig.shape == new.shape
 
-    # -- Zero-size and zero-extent --
 
-    def test_zero_size_zero_extent(self) -> None:
-        """FixedDimension(size=0, extent=0) => 0 chunks (consistent with size=0, extent=5)."""
-        d = FixedDimension(size=0, extent=0)
-        assert d.nchunks == 0
-        # OOB access tested via ChunkGrid.__getitem__, not direct method calls
-        g = ChunkGrid(dimensions=(d,))
-        assert g[0] is None
+# -- Zero-size and zero-extent --
 
-    def test_zero_size_nonzero_extent(self) -> None:
-        """FixedDimension(size=0, extent=5) => 0 chunks (can't partition)."""
-        d = FixedDimension(size=0, extent=5)
-        assert d.nchunks == 0
-        g = ChunkGrid(dimensions=(d,))
-        assert g[0] is None
 
-    def test_zero_extent_nonzero_size(self) -> None:
-        """FixedDimension(size=10, extent=0) => 0 chunks."""
-        d = FixedDimension(size=10, extent=0)
-        assert d.nchunks == 0
-        g = ChunkGrid(dimensions=(d,))
-        assert g[0] is None
+@pytest.mark.parametrize(
+    ("size", "extent"),
+    [(0, 0), (0, 5), (10, 0)],
+    ids=["zero-size-zero-extent", "zero-size-nonzero-extent", "zero-extent-nonzero-size"],
+)
+def test_edge_case_zero_size_or_extent(size: int, extent: int) -> None:
+    """FixedDimension with zero size or extent has zero chunks and getitem returns None"""
+    d = FixedDimension(size=size, extent=extent)
+    assert d.nchunks == 0
+    g = ChunkGrid(dimensions=(d,))
+    assert g[0] is None
 
-    # -- 0-d grid --
 
-    def test_0d_grid_getitem(self) -> None:
-        """0-d grid has exactly one chunk at coords ()."""
-        g = ChunkGrid.from_regular((), ())
-        spec = g[()]
-        assert spec is not None
-        assert spec.shape == ()
-        assert spec.codec_shape == ()
-        assert not spec.is_boundary
+# -- 0-d grid --
 
-    def test_0d_grid_iter(self) -> None:
-        """0-d grid iteration yields a single ChunkSpec."""
-        g = ChunkGrid.from_regular((), ())
-        specs = list(g)
-        assert len(specs) == 1
 
-    def test_0d_grid_all_chunk_coords(self) -> None:
-        """0-d grid has one chunk coord: the empty tuple."""
-        g = ChunkGrid.from_regular((), ())
-        coords = list(g.all_chunk_coords())
-        assert coords == [()]
+def test_0d_grid_getitem() -> None:
+    """0-d grid has exactly one chunk at coords ()."""
+    g = ChunkGrid.from_sizes((), ())
+    spec = g[()]
+    assert spec is not None
+    assert spec.shape == ()
+    assert spec.codec_shape == ()
+    assert not spec.is_boundary
 
-    def test_0d_grid_nchunks(self) -> None:
-        g = ChunkGrid.from_regular((), ())
-        assert g.get_nchunks() == 1
 
-    # -- parse_chunk_grid edge cases --
+def test_0d_grid_iter() -> None:
+    """0-d grid iteration yields a single ChunkSpec."""
+    g = ChunkGrid.from_sizes((), ())
+    specs = list(g)
+    assert len(specs) == 1
 
-    def test_parse_chunk_grid_preserves_varying_extent(self) -> None:
-        """parse_chunk_grid does not overwrite VaryingDimension extent."""
-        from zarr.core.chunk_grids import parse_chunk_grid
 
-        g = ChunkGrid.from_rectilinear([[10, 20, 30], [50, 50]], array_shape=(60, 100))
-        # VaryingDimension extent is 60 (sum of edges)
-        assert isinstance(g.dimensions[0], VaryingDimension)
-        assert g.dimensions[0].extent == 60
+def test_0d_grid_all_chunk_coords() -> None:
+    """0-d grid has one chunk coord: the empty tuple."""
+    g = ChunkGrid.from_sizes((), ())
+    coords = list(g.all_chunk_coords())
+    assert coords == [()]
 
-        # Re-binding with a different array shape should not change VaryingDimension
-        g2 = parse_chunk_grid(g, (60, 100))
-        assert isinstance(g2.dimensions[0], VaryingDimension)
-        assert g2.dimensions[0].extent == 60  # unchanged
 
-    def test_parse_chunk_grid_rebinds_fixed_extent(self) -> None:
-        """parse_chunk_grid updates FixedDimension extent from array shape."""
-        from zarr.core.chunk_grids import parse_chunk_grid
+def test_0d_grid_nchunks() -> None:
+    """0-d grid reports exactly one chunk"""
+    g = ChunkGrid.from_sizes((), ())
+    assert g.get_nchunks() == 1
 
-        g = ChunkGrid.from_regular((100, 200), (10, 20))
-        assert g.dimensions[0].extent == 100
 
-        g2 = parse_chunk_grid(g, (50, 100))
-        assert isinstance(g2.dimensions[0], FixedDimension)
-        assert g2.dimensions[0].extent == 50  # re-bound
-        assert g2.grid_shape == (5, 5)
+# -- parse_chunk_grid edge cases --
 
-    # -- ChunkGrid.__getitem__ validation --
 
-    def test_getitem_int_1d_regular(self) -> None:
-        """Integer indexing works for 1-d regular grids."""
-        g = ChunkGrid.from_regular((100,), (10,))
-        spec = g[0]
-        assert spec is not None
-        assert spec.shape == (10,)
-        assert spec.slices == (slice(0, 10, 1),)
-        # Boundary chunk
-        spec = g[9]
-        assert spec is not None
-        assert spec.shape == (10,)
+def test_parse_chunk_grid_preserves_varying_extent() -> None:
+    """parse_chunk_grid does not overwrite VaryingDimension extent."""
+    g = ChunkGrid.from_sizes((60, 100), [[10, 20, 30], [50, 50]])
+    assert isinstance(g.dimensions[0], VaryingDimension)
+    assert g.dimensions[0].extent == 60
 
-    def test_getitem_int_1d_rectilinear(self) -> None:
-        """Integer indexing works for 1-d rectilinear grids."""
-        g = ChunkGrid.from_rectilinear([[20, 30, 50]], array_shape=(100,))
-        spec = g[0]
-        assert spec is not None
-        assert spec.shape == (20,)
-        spec = g[1]
-        assert spec is not None
-        assert spec.shape == (30,)
-        spec = g[2]
-        assert spec is not None
-        assert spec.shape == (50,)
-
-    def test_getitem_int_0d_raises(self) -> None:
-        """Integer indexing raises ValueError for 0-d grids (ndim mismatch)."""
-        g = ChunkGrid.from_regular((), ())
-        with pytest.raises(ValueError, match="Expected 0 coordinate.*got 1"):
-            g[0]
-
-    def test_getitem_int_2d_raises(self) -> None:
-        """Integer indexing raises ValueError for 2-d grids (ndim mismatch)."""
-        g = ChunkGrid.from_regular((100, 200), (10, 20))
-        with pytest.raises(ValueError, match="Expected 2 coordinate.*got 1"):
-            g[0]
-
-    def test_getitem_int_oob_returns_none(self) -> None:
-        """Integer OOB returns None for 1-d grid."""
-        g = ChunkGrid.from_regular((100,), (10,))
-        assert g[10] is None
-        assert g[99] is None
-
-    def test_getitem_negative_index_returns_none(self) -> None:
-        g = ChunkGrid.from_regular((100,), (10,))
-        assert g[(-1,)] is None
-
-    def test_getitem_oob_returns_none(self) -> None:
-        g = ChunkGrid.from_regular((100,), (10,))
-        assert g[(10,)] is None
-        assert g[(99,)] is None
-
-    # -- ChunkSpec properties --
-
-    def test_chunk_spec_empty_slices(self) -> None:
-        """ChunkSpec with zero-width slice."""
-        spec = ChunkSpec(slices=(slice(10, 10),), codec_shape=(0,))
-        assert spec.shape == (0,)
-        assert not spec.is_boundary
-
-    def test_chunk_spec_multidim_boundary(self) -> None:
-        """is_boundary only when shape != codec_shape."""
-        spec = ChunkSpec(
-            slices=(slice(0, 10), slice(0, 5)),
-            codec_shape=(10, 10),
+    g2 = ChunkGrid(
+        dimensions=tuple(
+            dim.with_extent(ext) for dim, ext in zip(g.dimensions, (60, 100), strict=True)
         )
-        assert spec.shape == (10, 5)
-        assert spec.is_boundary  # second dim differs
+    )
+    assert isinstance(g2.dimensions[0], VaryingDimension)
+    assert g2.dimensions[0].extent == 60
 
-    # -- Rectilinear with zero-nchunks FixedDimension in serialize_chunk_grid --
 
-    def test_zero_nchunks_fixed_dim_in_rectilinear_serialize_raises(self) -> None:
-        """A rectilinear grid with a 0-extent dimension cannot be serialized."""
-        g = ChunkGrid(
-            dimensions=(
-                VaryingDimension([10, 20], extent=30),
-                FixedDimension(size=10, extent=0),
-            )
+def test_parse_chunk_grid_rebinds_fixed_extent() -> None:
+    """parse_chunk_grid updates FixedDimension extent from array shape."""
+    g = ChunkGrid.from_sizes((100, 200), (10, 20))
+    assert g.dimensions[0].extent == 100
+
+    g2 = ChunkGrid(
+        dimensions=tuple(
+            dim.with_extent(ext) for dim, ext in zip(g.dimensions, (50, 100), strict=True)
         )
-        assert g.grid_shape == (2, 0)
-        with pytest.raises(ValueError, match="zero-extent"):
-            serialize_chunk_grid(g, "rectilinear")
-
-    # -- VaryingDimension data_size --
-
-    def test_varying_dim_data_size_equals_chunk_size(self) -> None:
-        """For VaryingDimension, data_size == chunk_size (no padding)."""
-        d = VaryingDimension([10, 20, 5], extent=35)
-        for i in range(3):
-            assert d.data_size(i) == d.chunk_size(i)
+    )
+    assert isinstance(g2.dimensions[0], FixedDimension)
+    assert g2.dimensions[0].extent == 50
+    assert g2.grid_shape == (5, 5)
 
 
-class TestOrthogonalIndexerRectilinear:
-    """OrthogonalIndexer must use correct per-chunk sizes for VaryingDimension,
-    not a hardcoded 1. The chunk_shape field is used by ix_() to convert slices
-    to ranges for advanced indexing."""
+# -- ChunkGrid.__getitem__ validation --
 
-    def test_orthogonal_int_array_selection_rectilinear(self) -> None:
-        """Integer array selection with rectilinear grid must produce correct
-        chunk-local selections."""
-        from zarr.core.indexing import OrthogonalIndexer
 
-        g = ChunkGrid.from_rectilinear([[10, 20, 30], [50, 50]], array_shape=(60, 100))
-        indexer = OrthogonalIndexer(
-            selection=(np.array([5, 15, 35]), slice(None)),
-            shape=(60, 100),
-            chunk_grid=g,
+def test_getitem_int_1d_regular() -> None:
+    """Integer indexing works for 1-d regular grids."""
+    g = ChunkGrid.from_sizes((100,), (10,))
+    spec = g[0]
+    assert spec is not None
+    assert spec.shape == (10,)
+    assert spec.slices == (slice(0, 10, 1),)
+    spec = g[9]
+    assert spec is not None
+    assert spec.shape == (10,)
+
+
+def test_getitem_int_1d_rectilinear() -> None:
+    """Integer indexing works for 1-d rectilinear grids."""
+    g = ChunkGrid.from_sizes((100,), [[20, 30, 50]])
+    spec = g[0]
+    assert spec is not None
+    assert spec.shape == (20,)
+    spec = g[1]
+    assert spec is not None
+    assert spec.shape == (30,)
+    spec = g[2]
+    assert spec is not None
+    assert spec.shape == (50,)
+
+
+@pytest.mark.parametrize(
+    ("shape", "chunks", "match"),
+    [
+        ((), (), "Expected 0 coordinate.*got 1"),
+        ((100, 200), (10, 20), "Expected 2 coordinate.*got 1"),
+    ],
+    ids=["0d", "2d"],
+)
+def test_getitem_int_ndim_mismatch_raises(
+    shape: tuple[int, ...], chunks: tuple[int, ...], match: str
+) -> None:
+    """Integer indexing on a multi-dim or 0-d grid raises ValueError for ndim mismatch"""
+    g = ChunkGrid.from_sizes(shape, chunks)
+    with pytest.raises(ValueError, match=match):
+        g[0]
+
+
+@pytest.mark.parametrize(
+    "index",
+    [(10,), (99,), (-1,)],
+    ids=["oob-10", "oob-99", "negative"],
+)
+def test_getitem_oob_returns_none(index: tuple[int, ...]) -> None:
+    """Out-of-bounds or negative chunk indices return None"""
+    g = ChunkGrid.from_sizes((100,), (10,))
+    assert g[index] is None
+
+
+# -- Rectilinear with zero-nchunks FixedDimension --
+
+
+def test_zero_nchunks_fixed_dim_in_rectilinear() -> None:
+    """A rectilinear grid with a 0-extent FixedDimension still has valid size."""
+    g = ChunkGrid(
+        dimensions=(
+            VaryingDimension([10, 20], extent=30),
+            FixedDimension(size=10, extent=0),
         )
-        projections = list(indexer)
-        # Grid: dim0 chunks [0..10), [10..30), [30..60); dim1 chunks [0..50), [50..100)
-        # Indices 5, 15, 35 land in chunks 0, 1, 2 respectively.
-        # Combined with slice(None) over 2 dim1 chunks, we get 6 projections.
-        chunk_coords = [p.chunk_coords for p in projections]
-        assert chunk_coords == [(0, 0), (0, 1), (1, 0), (1, 1), (2, 0), (2, 1)]
-
-    def test_orthogonal_bool_array_selection_rectilinear(self) -> None:
-        """Boolean array selection with rectilinear grid produces correct chunk projections."""
-        from zarr.core.indexing import OrthogonalIndexer
-
-        # chunks: dim0 = [10, 20, 30], dim1 = [50, 50]
-        # mask selects: idx 5 (chunk 0), idx 15 (chunk 1), idx 35 (chunk 2)
-        g = ChunkGrid.from_rectilinear([[10, 20, 30], [50, 50]], array_shape=(60, 100))
-        mask = np.zeros(60, dtype=bool)
-        mask[5] = True
-        mask[15] = True
-        mask[35] = True
-        indexer = OrthogonalIndexer(
-            selection=(mask, slice(None)),
-            shape=(60, 100),
-            chunk_grid=g,
-        )
-        projections = list(indexer)
-        # 3 chunks touched in dim0 x 2 chunks in dim1 = 6 projections
-        assert len(projections) == 6
-        chunk_coords = [p.chunk_coords for p in projections]
-        assert (0, 0) in chunk_coords
-        assert (1, 0) in chunk_coords
-        assert (2, 0) in chunk_coords
-        assert (0, 1) in chunk_coords
-        assert (1, 1) in chunk_coords
-        assert (2, 1) in chunk_coords
-
-    def test_orthogonal_advanced_indexing_produces_correct_projections(self) -> None:
-        """Verify OrthogonalIndexer produces correct chunk projections
-        for advanced indexing with VaryingDimension."""
-        from zarr.core.indexing import OrthogonalIndexer
-
-        g = ChunkGrid.from_rectilinear([[10, 20, 30], [50, 50]], array_shape=(60, 100))
-        indexer = OrthogonalIndexer(
-            selection=(np.array([5, 15]), slice(None)),
-            shape=(60, 100),
-            chunk_grid=g,
-        )
-        projections = list(indexer)
-        # index 5 is in chunk 0 (edges [10,...]), index 15 is in chunk 1 (edges [...,20,...])
-        # dim 1 slice(None) covers both chunks [50, 50]
-        # cartesian product: 2 chunks in dim 0 x 2 chunks in dim 1 = 4 projections
-        assert len(projections) == 4
-        coords = [p.chunk_coords for p in projections]
-        assert (0, 0) in coords
-        assert (0, 1) in coords
-        assert (1, 0) in coords
-        assert (1, 1) in coords
+    )
+    assert g.grid_shape == (2, 0)
 
 
-class TestShardingValidationRectilinear:
-    """ShardingCodec.validate must check divisibility for rectilinear grids too."""
-
-    def test_sharding_rejects_non_divisible_rectilinear(self) -> None:
-        """Rectilinear shard sizes not divisible by inner chunk_shape should raise."""
-        from zarr.codecs.sharding import ShardingCodec
-        from zarr.core.dtype import Float32
-        from zarr.core.metadata.v3 import RectilinearChunkGrid
-
-        codec = ShardingCodec(chunk_shape=(5, 5))
-        # 17 is not divisible by 5
-        grid_meta = RectilinearChunkGrid(chunk_shapes=((10, 20, 17), (50, 50)))
-
-        with pytest.raises(ValueError, match="divisible"):
-            codec.validate(
-                shape=(47, 100),
-                dtype=Float32(),
-                chunk_grid=grid_meta,
-            )
-
-    def test_sharding_accepts_divisible_rectilinear(self) -> None:
-        """Rectilinear shard sizes all divisible by inner chunk_shape should pass."""
-        from zarr.codecs.sharding import ShardingCodec
-        from zarr.core.dtype import Float32
-        from zarr.core.metadata.v3 import RectilinearChunkGrid
-
-        codec = ShardingCodec(chunk_shape=(5, 5))
-        grid_meta = RectilinearChunkGrid(chunk_shapes=((10, 20, 30), (50, 50)))
-
-        # Should not raise
-        codec.validate(
-            shape=(60, 100),
-            dtype=Float32(),
-            chunk_grid=grid_meta,
-        )
+# -- VaryingDimension data_size --
 
 
-class TestFullPipelineRectilinear:
-    """End-to-end read/write tests through the full Array pipeline."""
+def test_varying_dim_data_size_equals_chunk_size() -> None:
+    """For VaryingDimension, data_size == chunk_size (no padding)."""
+    d = VaryingDimension([10, 20, 5], extent=35)
+    for i in range(3):
+        assert d.data_size(i) == d.chunk_size(i)
 
-    @staticmethod
-    def _make_1d(tmp_path: Path) -> tuple[zarr.Array[Any], np.ndarray[Any, Any]]:
-        a = np.arange(30, dtype="int32")
-        z = zarr.create_array(
-            store=tmp_path / "arr1d.zarr",
+
+# ---------------------------------------------------------------------------
+# OrthogonalIndexer rectilinear tests
+# ---------------------------------------------------------------------------
+
+
+def test_orthogonal_int_array_selection_rectilinear() -> None:
+    """Integer array selection with rectilinear grid must produce correct
+    chunk-local selections."""
+    from zarr.core.indexing import OrthogonalIndexer
+
+    g = ChunkGrid.from_sizes((60, 100), [[10, 20, 30], [50, 50]])
+    indexer = OrthogonalIndexer(
+        selection=(np.array([5, 15, 35]), slice(None)),
+        shape=(60, 100),
+        chunk_grid=g,
+    )
+    projections = list(indexer)
+    chunk_coords = [p.chunk_coords for p in projections]
+    assert chunk_coords == [(0, 0), (0, 1), (1, 0), (1, 1), (2, 0), (2, 1)]
+
+
+def test_orthogonal_bool_array_selection_rectilinear() -> None:
+    """Boolean array selection with rectilinear grid produces correct chunk projections."""
+    from zarr.core.indexing import OrthogonalIndexer
+
+    g = ChunkGrid.from_sizes((60, 100), [[10, 20, 30], [50, 50]])
+    mask = np.zeros(60, dtype=bool)
+    mask[5] = True
+    mask[15] = True
+    mask[35] = True
+    indexer = OrthogonalIndexer(
+        selection=(mask, slice(None)),
+        shape=(60, 100),
+        chunk_grid=g,
+    )
+    projections = list(indexer)
+    assert len(projections) == 6
+    chunk_coords = [p.chunk_coords for p in projections]
+    assert (0, 0) in chunk_coords
+    assert (1, 0) in chunk_coords
+    assert (2, 0) in chunk_coords
+    assert (0, 1) in chunk_coords
+    assert (1, 1) in chunk_coords
+    assert (2, 1) in chunk_coords
+
+
+def test_orthogonal_advanced_indexing_produces_correct_projections() -> None:
+    """Verify OrthogonalIndexer produces correct chunk projections
+    for advanced indexing with VaryingDimension."""
+    from zarr.core.indexing import OrthogonalIndexer
+
+    g = ChunkGrid.from_sizes((60, 100), [[10, 20, 30], [50, 50]])
+    indexer = OrthogonalIndexer(
+        selection=(np.array([5, 15]), slice(None)),
+        shape=(60, 100),
+        chunk_grid=g,
+    )
+    projections = list(indexer)
+    assert len(projections) == 4
+    coords = [p.chunk_coords for p in projections]
+    assert (0, 0) in coords
+    assert (0, 1) in coords
+    assert (1, 0) in coords
+    assert (1, 1) in coords
+
+
+# ---------------------------------------------------------------------------
+# Full pipeline rectilinear tests (helpers)
+# ---------------------------------------------------------------------------
+
+
+def _make_1d(tmp_path: Path) -> tuple[zarr.Array[Any], np.ndarray[Any, Any]]:
+    a = np.arange(30, dtype="int32")
+    z = zarr.create_array(
+        store=tmp_path / "arr1d.zarr",
+        shape=(30,),
+        chunks=[[5, 10, 15]],
+        dtype="int32",
+    )
+    z[:] = a
+    return z, a
+
+
+def _make_2d(tmp_path: Path) -> tuple[zarr.Array[Any], np.ndarray[Any, Any]]:
+    a = np.arange(6000, dtype="int32").reshape(60, 100)
+    z = zarr.create_array(
+        store=tmp_path / "arr2d.zarr",
+        shape=(60, 100),
+        chunks=[[10, 20, 30], [25, 25, 25, 25]],
+        dtype="int32",
+    )
+    z[:] = a
+    return z, a
+
+
+# --- Basic selection ---
+
+
+def test_pipeline_basic_selection_1d(tmp_path: Path) -> None:
+    """1D rectilinear basic selections match numpy for ints, slices, and full-array reads"""
+    z, a = _make_1d(tmp_path)
+    sels: list[Any] = [0, 4, 5, 14, 15, 29, -1, slice(None), slice(3, 18), slice(0, 0)]
+    for sel in sels:
+        np.testing.assert_array_equal(z[sel], a[sel], err_msg=f"sel={sel}")
+
+
+def test_pipeline_basic_selection_1d_strided(tmp_path: Path) -> None:
+    """1D rectilinear strided slice selections match numpy"""
+    z, a = _make_1d(tmp_path)
+    for sel in [slice(None, None, 2), slice(1, 25, 3), slice(0, 30, 7)]:
+        np.testing.assert_array_equal(z[sel], a[sel], err_msg=f"sel={sel}")
+
+
+def test_pipeline_basic_selection_2d(tmp_path: Path) -> None:
+    """2D rectilinear basic selections match numpy across chunk boundaries"""
+    z, a = _make_2d(tmp_path)
+    selections: list[Any] = [
+        42,
+        -1,
+        (9, 24),
+        (10, 25),
+        (30, 50),
+        (59, 99),
+        slice(None),
+        (slice(5, 35), slice(20, 80)),
+        (slice(0, 10), slice(0, 25)),
+        (slice(10, 10), slice(None)),
+        (slice(None, None, 3), slice(None, None, 7)),
+    ]
+    for sel in selections:
+        np.testing.assert_array_equal(z[sel], a[sel], err_msg=f"sel={sel}")
+
+
+# --- Orthogonal selection ---
+
+
+def test_pipeline_orthogonal_selection_1d_bool(tmp_path: Path) -> None:
+    """1D boolean orthogonal indexing on rectilinear arrays matches numpy"""
+    z, a = _make_1d(tmp_path)
+    ix = np.zeros(30, dtype=bool)
+    ix[[0, 4, 5, 14, 15, 29]] = True
+    np.testing.assert_array_equal(z.oindex[ix], a[ix])
+
+
+def test_pipeline_orthogonal_selection_1d_int(tmp_path: Path) -> None:
+    """1D integer and negative-index orthogonal selection on rectilinear arrays matches numpy"""
+    z, a = _make_1d(tmp_path)
+    ix = np.array([0, 4, 5, 14, 15, 29])
+    np.testing.assert_array_equal(z.oindex[ix], a[ix])
+    ix_neg = np.array([0, -1, -15, -25])
+    np.testing.assert_array_equal(z.oindex[ix_neg], a[ix_neg])
+
+
+def test_pipeline_orthogonal_selection_2d_bool(tmp_path: Path) -> None:
+    """2D boolean orthogonal selection on rectilinear arrays matches numpy"""
+    z, a = _make_2d(tmp_path)
+    ix0 = np.zeros(60, dtype=bool)
+    ix0[[0, 9, 10, 29, 30, 59]] = True
+    ix1 = np.zeros(100, dtype=bool)
+    ix1[[0, 24, 25, 49, 50, 99]] = True
+    np.testing.assert_array_equal(z.oindex[ix0, ix1], a[np.ix_(ix0, ix1)])
+
+
+def test_pipeline_orthogonal_selection_2d_int(tmp_path: Path) -> None:
+    """2D integer orthogonal selection on rectilinear arrays matches numpy"""
+    z, a = _make_2d(tmp_path)
+    ix0 = np.array([0, 9, 10, 29, 30, 59])
+    ix1 = np.array([0, 24, 25, 49, 50, 99])
+    np.testing.assert_array_equal(z.oindex[ix0, ix1], a[np.ix_(ix0, ix1)])
+
+
+def test_pipeline_orthogonal_selection_2d_mixed(tmp_path: Path) -> None:
+    """2D mixed int-array and slice orthogonal selection on rectilinear arrays matches numpy"""
+    z, a = _make_2d(tmp_path)
+    ix = np.array([0, 9, 10, 29, 30, 59])
+    np.testing.assert_array_equal(z.oindex[ix, slice(25, 75)], a[np.ix_(ix, np.arange(25, 75))])
+    np.testing.assert_array_equal(
+        z.oindex[slice(10, 30), ix[:4]], a[np.ix_(np.arange(10, 30), ix[:4])]
+    )
+
+
+# --- Coordinate (vindex) selection ---
+
+
+def test_pipeline_coordinate_selection_1d(tmp_path: Path) -> None:
+    """1D coordinate (vindex) selection on rectilinear arrays matches numpy"""
+    z, a = _make_1d(tmp_path)
+    ix = np.array([0, 4, 5, 14, 15, 29])
+    np.testing.assert_array_equal(z.vindex[ix], a[ix])
+
+
+def test_pipeline_coordinate_selection_2d(tmp_path: Path) -> None:
+    """2D coordinate (vindex) selection on rectilinear arrays matches numpy"""
+    z, a = _make_2d(tmp_path)
+    r = np.array([0, 9, 10, 29, 30, 59])
+    c = np.array([0, 24, 25, 49, 50, 99])
+    np.testing.assert_array_equal(z.vindex[r, c], a[r, c])
+
+
+def test_pipeline_coordinate_selection_2d_bool_mask(tmp_path: Path) -> None:
+    """2D boolean mask vindex selection on rectilinear arrays matches numpy"""
+    z, a = _make_2d(tmp_path)
+    mask = a > 3000
+    np.testing.assert_array_equal(z.vindex[mask], a[mask])
+
+
+# --- Block selection ---
+
+
+def test_pipeline_block_selection_1d(tmp_path: Path) -> None:
+    """1D block selection on rectilinear arrays returns correct chunk data"""
+    z, a = _make_1d(tmp_path)
+    np.testing.assert_array_equal(z.blocks[0], a[0:5])
+    np.testing.assert_array_equal(z.blocks[1], a[5:15])
+    np.testing.assert_array_equal(z.blocks[2], a[15:30])
+    np.testing.assert_array_equal(z.blocks[-1], a[15:30])
+    np.testing.assert_array_equal(z.blocks[0:2], a[0:15])
+    np.testing.assert_array_equal(z.blocks[1:3], a[5:30])
+    np.testing.assert_array_equal(z.blocks[:], a[:])
+
+
+def test_pipeline_block_selection_2d(tmp_path: Path) -> None:
+    """2D block selection on rectilinear arrays returns correct chunk data"""
+    z, a = _make_2d(tmp_path)
+    np.testing.assert_array_equal(z.blocks[0, 0], a[0:10, 0:25])
+    np.testing.assert_array_equal(z.blocks[1, 2], a[10:30, 50:75])
+    np.testing.assert_array_equal(z.blocks[2, 3], a[30:60, 75:100])
+    np.testing.assert_array_equal(z.blocks[-1, -1], a[30:60, 75:100])
+    np.testing.assert_array_equal(z.blocks[0:2, 1:3], a[0:30, 25:75])
+    np.testing.assert_array_equal(z.blocks[:, :], a[:, :])
+
+
+def test_pipeline_set_block_selection_1d(tmp_path: Path) -> None:
+    """Writing via 1D block selection on rectilinear arrays persists correctly"""
+    z, a = _make_1d(tmp_path)
+    val = np.full(10, -1, dtype="int32")
+    z.blocks[1] = val
+    a[5:15] = val
+    np.testing.assert_array_equal(z[:], a)
+
+
+def test_pipeline_set_block_selection_2d(tmp_path: Path) -> None:
+    """Writing via 2D block selection on rectilinear arrays persists correctly"""
+    z, a = _make_2d(tmp_path)
+    val = np.full((30, 50), -99, dtype="int32")
+    z.blocks[0:2, 1:3] = val
+    a[0:30, 25:75] = val
+    np.testing.assert_array_equal(z[:], a)
+
+
+def test_pipeline_block_selection_slice_stop_at_nchunks(tmp_path: Path) -> None:
+    """Block slice with stop == nchunks exercises the dim_len fallback."""
+    z, a = _make_1d(tmp_path)
+    np.testing.assert_array_equal(z.blocks[1:3], a[5:30])
+    np.testing.assert_array_equal(z.blocks[0:10], a[:])
+
+
+def test_pipeline_block_selection_slice_stop_at_nchunks_2d(tmp_path: Path) -> None:
+    """Same fallback test for 2D rectilinear arrays."""
+    z, a = _make_2d(tmp_path)
+    np.testing.assert_array_equal(z.blocks[2:3, 3:4], a[30:60, 75:100])
+    np.testing.assert_array_equal(z.blocks[0:99, 0:99], a[:, :])
+
+
+# --- Set coordinate selection ---
+
+
+def test_pipeline_set_coordinate_selection_1d(tmp_path: Path) -> None:
+    """Writing via 1D coordinate selection on rectilinear arrays persists correctly"""
+    z, a = _make_1d(tmp_path)
+    ix = np.array([0, 4, 5, 14, 15, 29])
+    val = np.full(len(ix), -7, dtype="int32")
+    z.vindex[ix] = val
+    a[ix] = val
+    np.testing.assert_array_equal(z[:], a)
+
+
+def test_pipeline_set_coordinate_selection_2d(tmp_path: Path) -> None:
+    """Writing via 2D coordinate selection on rectilinear arrays persists correctly"""
+    z, a = _make_2d(tmp_path)
+    r = np.array([0, 9, 10, 29, 30, 59])
+    c = np.array([0, 24, 25, 49, 50, 99])
+    val = np.full(len(r), -42, dtype="int32")
+    z.vindex[r, c] = val
+    a[r, c] = val
+    np.testing.assert_array_equal(z[:], a)
+
+
+# --- Set selection ---
+
+
+def test_pipeline_set_basic_selection(tmp_path: Path) -> None:
+    """Writing via basic slice selection on rectilinear arrays persists correctly"""
+    z, a = _make_2d(tmp_path)
+    new_data = np.full((20, 50), -1, dtype="int32")
+    z[5:25, 10:60] = new_data
+    a[5:25, 10:60] = new_data
+    np.testing.assert_array_equal(z[:], a)
+
+
+def test_pipeline_set_orthogonal_selection(tmp_path: Path) -> None:
+    """Writing via orthogonal selection on rectilinear arrays persists correctly"""
+    z, a = _make_2d(tmp_path)
+    rows = np.array([0, 10, 30])
+    cols = np.array([0, 25, 50, 75])
+    val = np.full((3, 4), -99, dtype="int32")
+    z.oindex[rows, cols] = val
+    a[np.ix_(rows, cols)] = val
+    np.testing.assert_array_equal(z[:], a)
+
+
+# --- Higher dimensions ---
+
+
+def test_pipeline_3d_array(tmp_path: Path) -> None:
+    """3D rectilinear array write and read-back match numpy"""
+    shape = (12, 20, 15)
+    chunk_shapes = [[4, 8], [5, 5, 10], [5, 10]]
+    a = np.arange(int(np.prod(shape)), dtype="int32").reshape(shape)
+    z = zarr.create_array(
+        store=tmp_path / "arr3d.zarr",
+        shape=shape,
+        chunks=chunk_shapes,
+        dtype="int32",
+    )
+    z[:] = a
+    np.testing.assert_array_equal(z[:], a)
+    np.testing.assert_array_equal(z[2:10, 3:18, 4:14], a[2:10, 3:18, 4:14])
+
+
+def test_pipeline_1d_single_chunk(tmp_path: Path) -> None:
+    """Single-chunk rectilinear array write and read-back match numpy"""
+    a = np.arange(20, dtype="int32")
+    z = zarr.create_array(
+        store=tmp_path / "arr1c.zarr",
+        shape=(20,),
+        chunks=[[20]],
+        dtype="int32",
+    )
+    z[:] = a
+    np.testing.assert_array_equal(z[:], a)
+
+
+# --- Persistence roundtrip ---
+
+
+def test_pipeline_persistence_roundtrip(tmp_path: Path) -> None:
+    """Rectilinear array survives close and reopen with correct data"""
+    _, a = _make_2d(tmp_path)
+    z2 = zarr.open_array(store=tmp_path / "arr2d.zarr", mode="r")
+    assert not z2.chunk_grid.is_regular
+    np.testing.assert_array_equal(z2[:], a)
+
+
+# --- Highly irregular chunks ---
+
+
+def test_pipeline_highly_irregular_chunks(tmp_path: Path) -> None:
+    """Highly irregular chunk sizes produce correct write and partial-read results"""
+    shape = (100, 100)
+    chunk_shapes = [[5, 10, 15, 20, 50], [100]]
+    a = np.arange(10000, dtype="int32").reshape(shape)
+    z = zarr.create_array(
+        store=tmp_path / "irreg.zarr",
+        shape=shape,
+        chunks=chunk_shapes,
+        dtype="int32",
+    )
+    z[:] = a
+    np.testing.assert_array_equal(z[:], a)
+    np.testing.assert_array_equal(z[3:97, 10:90], a[3:97, 10:90])
+
+
+# --- API validation ---
+
+
+def test_pipeline_v2_rejects_rectilinear(tmp_path: Path) -> None:
+    """Creating a rectilinear array with zarr_format=2 raises ValueError"""
+    with pytest.raises(ValueError, match="Zarr format 2"):
+        zarr.create_array(
+            store=tmp_path / "v2.zarr",
             shape=(30,),
-            chunks=[[5, 10, 15]],
+            chunks=[[10, 20]],
             dtype="int32",
+            zarr_format=2,
         )
-        z[:] = a
-        return z, a
 
-    @staticmethod
-    def _make_2d(tmp_path: Path) -> tuple[zarr.Array[Any], np.ndarray[Any, Any]]:
-        a = np.arange(6000, dtype="int32").reshape(60, 100)
-        z = zarr.create_array(
-            store=tmp_path / "arr2d.zarr",
+
+def test_pipeline_sharding_rejects_rectilinear_chunks_with_shards(tmp_path: Path) -> None:
+    """Rectilinear chunks (inner) with sharding is not supported."""
+    with pytest.raises(ValueError, match="Rectilinear chunks with sharding"):
+        zarr.create_array(
+            store=tmp_path / "shard.zarr",
             shape=(60, 100),
             chunks=[[10, 20, 30], [25, 25, 25, 25]],
+            shards=(30, 50),
             dtype="int32",
         )
-        z[:] = a
-        return z, a
 
-    # --- Basic selection ---
 
-    def test_basic_selection_1d(self, tmp_path: Path) -> None:
-        z, a = self._make_1d(tmp_path)
-        sels: list[Any] = [0, 4, 5, 14, 15, 29, -1, slice(None), slice(3, 18), slice(0, 0)]
-        for sel in sels:
-            np.testing.assert_array_equal(z[sel], a[sel], err_msg=f"sel={sel}")
+def test_pipeline_rectilinear_shards_roundtrip(tmp_path: Path) -> None:
+    """Rectilinear shards with uniform inner chunks: full write/read roundtrip."""
+    data = np.arange(120 * 100, dtype="int32").reshape(120, 100)
+    arr = zarr.create_array(
+        store=tmp_path / "rect_shards.zarr",
+        shape=(120, 100),
+        chunks=(10, 10),
+        shards=[[60, 40, 20], [50, 50]],
+        dtype="int32",
+    )
+    arr[:] = data
+    result = arr[:]
+    np.testing.assert_array_equal(result, data)
 
-    def test_basic_selection_1d_strided(self, tmp_path: Path) -> None:
-        z, a = self._make_1d(tmp_path)
-        for sel in [slice(None, None, 2), slice(1, 25, 3), slice(0, 30, 7)]:
-            np.testing.assert_array_equal(z[sel], a[sel], err_msg=f"sel={sel}")
 
-    def test_basic_selection_2d(self, tmp_path: Path) -> None:
-        z, a = self._make_2d(tmp_path)
-        selections: list[Any] = [
-            42,
-            -1,
-            (9, 24),
-            (10, 25),
-            (30, 50),
-            (59, 99),
-            slice(None),
-            (slice(5, 35), slice(20, 80)),
-            (slice(0, 10), slice(0, 25)),  # within one chunk
-            (slice(10, 10), slice(None)),  # empty
-            (slice(None, None, 3), slice(None, None, 7)),  # strided
-        ]
-        for sel in selections:
-            np.testing.assert_array_equal(z[sel], a[sel], err_msg=f"sel={sel}")
+def test_pipeline_rectilinear_shards_partial_read(tmp_path: Path) -> None:
+    """Partial reads across rectilinear shard boundaries."""
+    data = np.arange(120 * 100, dtype="float64").reshape(120, 100)
+    arr = zarr.create_array(
+        store=tmp_path / "rect_shards.zarr",
+        shape=(120, 100),
+        chunks=(10, 10),
+        shards=[[60, 40, 20], [50, 50]],
+        dtype="float64",
+    )
+    arr[:] = data
+    result = arr[50:70, 40:60]
+    np.testing.assert_array_equal(result, data[50:70, 40:60])
 
-    # --- Orthogonal selection ---
 
-    def test_orthogonal_selection_1d_bool(self, tmp_path: Path) -> None:
-        z, a = self._make_1d(tmp_path)
-        ix = np.zeros(30, dtype=bool)
-        ix[[0, 4, 5, 14, 15, 29]] = True
-        np.testing.assert_array_equal(z.oindex[ix], a[ix])
-
-    def test_orthogonal_selection_1d_int(self, tmp_path: Path) -> None:
-        z, a = self._make_1d(tmp_path)
-        ix = np.array([0, 4, 5, 14, 15, 29])
-        np.testing.assert_array_equal(z.oindex[ix], a[ix])
-        ix_neg = np.array([0, -1, -15, -25])
-        np.testing.assert_array_equal(z.oindex[ix_neg], a[ix_neg])
-
-    def test_orthogonal_selection_2d_bool(self, tmp_path: Path) -> None:
-        z, a = self._make_2d(tmp_path)
-        ix0 = np.zeros(60, dtype=bool)
-        ix0[[0, 9, 10, 29, 30, 59]] = True
-        ix1 = np.zeros(100, dtype=bool)
-        ix1[[0, 24, 25, 49, 50, 99]] = True
-        np.testing.assert_array_equal(z.oindex[ix0, ix1], a[np.ix_(ix0, ix1)])
-
-    def test_orthogonal_selection_2d_int(self, tmp_path: Path) -> None:
-        z, a = self._make_2d(tmp_path)
-        ix0 = np.array([0, 9, 10, 29, 30, 59])
-        ix1 = np.array([0, 24, 25, 49, 50, 99])
-        np.testing.assert_array_equal(z.oindex[ix0, ix1], a[np.ix_(ix0, ix1)])
-
-    def test_orthogonal_selection_2d_mixed(self, tmp_path: Path) -> None:
-        z, a = self._make_2d(tmp_path)
-        ix = np.array([0, 9, 10, 29, 30, 59])
-        np.testing.assert_array_equal(z.oindex[ix, slice(25, 75)], a[np.ix_(ix, np.arange(25, 75))])
-        np.testing.assert_array_equal(
-            z.oindex[slice(10, 30), ix[:4]], a[np.ix_(np.arange(10, 30), ix[:4])]
-        )
-
-    # --- Coordinate (vindex) selection ---
-
-    def test_coordinate_selection_1d(self, tmp_path: Path) -> None:
-        z, a = self._make_1d(tmp_path)
-        ix = np.array([0, 4, 5, 14, 15, 29])
-        np.testing.assert_array_equal(z.vindex[ix], a[ix])
-
-    def test_coordinate_selection_2d(self, tmp_path: Path) -> None:
-        z, a = self._make_2d(tmp_path)
-        r = np.array([0, 9, 10, 29, 30, 59])
-        c = np.array([0, 24, 25, 49, 50, 99])
-        np.testing.assert_array_equal(z.vindex[r, c], a[r, c])
-
-    def test_coordinate_selection_2d_bool_mask(self, tmp_path: Path) -> None:
-        z, a = self._make_2d(tmp_path)
-        mask = a > 3000
-        np.testing.assert_array_equal(z.vindex[mask], a[mask])
-
-    # --- Block selection ---
-
-    def test_block_selection_1d(self, tmp_path: Path) -> None:
-        z, a = self._make_1d(tmp_path)
-        # chunks: [5, 10, 15] -> offsets 0, 5, 15
-        # block 0: a[0:5], block 1: a[5:15], block 2: a[15:30]
-        np.testing.assert_array_equal(z.blocks[0], a[0:5])
-        np.testing.assert_array_equal(z.blocks[1], a[5:15])
-        np.testing.assert_array_equal(z.blocks[2], a[15:30])
-        np.testing.assert_array_equal(z.blocks[-1], a[15:30])
-        # slice of blocks
-        np.testing.assert_array_equal(z.blocks[0:2], a[0:15])
-        np.testing.assert_array_equal(z.blocks[1:3], a[5:30])
-        np.testing.assert_array_equal(z.blocks[:], a[:])
-
-    def test_block_selection_2d(self, tmp_path: Path) -> None:
-        z, a = self._make_2d(tmp_path)
-        # dim0 chunks: [10, 20, 30] -> offsets 0, 10, 30
-        # dim1 chunks: [25, 25, 25, 25] -> offsets 0, 25, 50, 75
-        np.testing.assert_array_equal(z.blocks[0, 0], a[0:10, 0:25])
-        np.testing.assert_array_equal(z.blocks[1, 2], a[10:30, 50:75])
-        np.testing.assert_array_equal(z.blocks[2, 3], a[30:60, 75:100])
-        np.testing.assert_array_equal(z.blocks[-1, -1], a[30:60, 75:100])
-        # slice of blocks
-        np.testing.assert_array_equal(z.blocks[0:2, 1:3], a[0:30, 25:75])
-        np.testing.assert_array_equal(z.blocks[:, :], a[:, :])
-
-    def test_set_block_selection_1d(self, tmp_path: Path) -> None:
-        z, a = self._make_1d(tmp_path)
-        # overwrite block 1 (a[5:15])
-        val = np.full(10, -1, dtype="int32")
-        z.blocks[1] = val
-        a[5:15] = val
-        np.testing.assert_array_equal(z[:], a)
-
-    def test_set_block_selection_2d(self, tmp_path: Path) -> None:
-        z, a = self._make_2d(tmp_path)
-        # overwrite blocks [0:2, 1:3] -> a[0:30, 25:75]
-        val = np.full((30, 50), -99, dtype="int32")
-        z.blocks[0:2, 1:3] = val
-        a[0:30, 25:75] = val
-        np.testing.assert_array_equal(z[:], a)
-
-    def test_block_selection_slice_stop_at_nchunks(self, tmp_path: Path) -> None:
-        """Block slice with stop == nchunks exercises the dim_len fallback
-        in BlockIndexer (``chunk_offset(stop) if stop < nchunks else dim_len``).
-        """
-        z, a = self._make_1d(tmp_path)
-        # nchunks == 3; stop=3 hits the `else dim_len` path
-        np.testing.assert_array_equal(z.blocks[1:3], a[5:30])
-        # stop > nchunks should also produce the full remainder
-        np.testing.assert_array_equal(z.blocks[0:10], a[:])
-
-    def test_block_selection_slice_stop_at_nchunks_2d(self, tmp_path: Path) -> None:
-        """Same fallback test for 2D rectilinear arrays."""
-        z, a = self._make_2d(tmp_path)
-        # dim0 nchunks=3, dim1 nchunks=4
-        np.testing.assert_array_equal(z.blocks[2:3, 3:4], a[30:60, 75:100])
-        np.testing.assert_array_equal(z.blocks[0:99, 0:99], a[:, :])
-
-    # --- Set coordinate selection ---
-
-    def test_set_coordinate_selection_1d(self, tmp_path: Path) -> None:
-        z, a = self._make_1d(tmp_path)
-        ix = np.array([0, 4, 5, 14, 15, 29])
-        val = np.full(len(ix), -7, dtype="int32")
-        z.vindex[ix] = val
-        a[ix] = val
-        np.testing.assert_array_equal(z[:], a)
-
-    def test_set_coordinate_selection_2d(self, tmp_path: Path) -> None:
-        z, a = self._make_2d(tmp_path)
-        r = np.array([0, 9, 10, 29, 30, 59])
-        c = np.array([0, 24, 25, 49, 50, 99])
-        val = np.full(len(r), -42, dtype="int32")
-        z.vindex[r, c] = val
-        a[r, c] = val
-        np.testing.assert_array_equal(z[:], a)
-
-    # --- Set selection ---
-
-    def test_set_basic_selection(self, tmp_path: Path) -> None:
-        z, a = self._make_2d(tmp_path)
-        new_data = np.full((20, 50), -1, dtype="int32")
-        z[5:25, 10:60] = new_data
-        a[5:25, 10:60] = new_data
-        np.testing.assert_array_equal(z[:], a)
-
-    def test_set_orthogonal_selection(self, tmp_path: Path) -> None:
-        z, a = self._make_2d(tmp_path)
-        rows = np.array([0, 10, 30])
-        cols = np.array([0, 25, 50, 75])
-        val = np.full((3, 4), -99, dtype="int32")
-        z.oindex[rows, cols] = val
-        a[np.ix_(rows, cols)] = val
-        np.testing.assert_array_equal(z[:], a)
-
-    # --- Higher dimensions ---
-
-    def test_3d_array(self, tmp_path: Path) -> None:
-        shape = (12, 20, 15)
-        chunk_shapes = [[4, 8], [5, 5, 10], [5, 10]]
-        a = np.arange(int(np.prod(shape)), dtype="int32").reshape(shape)
-        z = zarr.create_array(
-            store=tmp_path / "arr3d.zarr",
-            shape=shape,
-            chunks=chunk_shapes,
-            dtype="int32",
-        )
-        z[:] = a
-        np.testing.assert_array_equal(z[:], a)
-        np.testing.assert_array_equal(z[2:10, 3:18, 4:14], a[2:10, 3:18, 4:14])
-
-    def test_1d_single_chunk(self, tmp_path: Path) -> None:
-        a = np.arange(20, dtype="int32")
-        z = zarr.create_array(
-            store=tmp_path / "arr1c.zarr",
-            shape=(20,),
-            chunks=[[20]],
-            dtype="int32",
-        )
-        z[:] = a
-        np.testing.assert_array_equal(z[:], a)
-
-    # --- Persistence roundtrip ---
-
-    def test_persistence_roundtrip(self, tmp_path: Path) -> None:
-        _, a = self._make_2d(tmp_path)
-        z2 = zarr.open_array(store=tmp_path / "arr2d.zarr", mode="r")
-        assert not z2.chunk_grid.is_regular
-        np.testing.assert_array_equal(z2[:], a)
-
-    # --- Highly irregular chunks ---
-
-    def test_highly_irregular_chunks(self, tmp_path: Path) -> None:
-        shape = (100, 100)
-        chunk_shapes = [[5, 10, 15, 20, 50], [100]]
-        a = np.arange(10000, dtype="int32").reshape(shape)
-        z = zarr.create_array(
-            store=tmp_path / "irreg.zarr",
-            shape=shape,
-            chunks=chunk_shapes,
-            dtype="int32",
-        )
-        z[:] = a
-        np.testing.assert_array_equal(z[:], a)
-        np.testing.assert_array_equal(z[3:97, 10:90], a[3:97, 10:90])
-
-    # --- API validation ---
-
-    def test_v2_rejects_rectilinear(self, tmp_path: Path) -> None:
-        with pytest.raises(ValueError, match="Zarr format 2"):
-            zarr.create_array(
-                store=tmp_path / "v2.zarr",
-                shape=(30,),
-                chunks=[[10, 20]],
-                dtype="int32",
-                zarr_format=2,
-            )
-
-    def test_sharding_rejects_rectilinear_chunks_with_shards(self, tmp_path: Path) -> None:
-        """Rectilinear chunks (inner) with sharding is not supported."""
-        with pytest.raises(ValueError, match="Rectilinear chunks with sharding"):
-            zarr.create_array(
-                store=tmp_path / "shard.zarr",
-                shape=(60, 100),
-                chunks=[[10, 20, 30], [25, 25, 25, 25]],
-                shards=(30, 50),
-                dtype="int32",
-            )
-
-    def test_rectilinear_shards_roundtrip(self, tmp_path: Path) -> None:
-        """Rectilinear shards with uniform inner chunks: full write/read roundtrip."""
-        import numpy as np
-
-        data = np.arange(120 * 100, dtype="int32").reshape(120, 100)
-        arr = zarr.create_array(
-            store=tmp_path / "rect_shards.zarr",
-            shape=(120, 100),
-            chunks=(10, 10),  # uniform inner chunks
-            shards=[[60, 40, 20], [50, 50]],  # rectilinear shard boundaries
-            dtype="int32",
-        )
-        arr[:] = data
-        result = arr[:]
-        np.testing.assert_array_equal(result, data)
-
-    def test_rectilinear_shards_partial_read(self, tmp_path: Path) -> None:
-        """Partial reads across rectilinear shard boundaries."""
-        import numpy as np
-
-        data = np.arange(120 * 100, dtype="float64").reshape(120, 100)
-        arr = zarr.create_array(
-            store=tmp_path / "rect_shards.zarr",
+def test_pipeline_rectilinear_shards_validates_divisibility(tmp_path: Path) -> None:
+    """Inner chunk_shape must divide every shard's dimensions."""
+    with pytest.raises(ValueError, match="divisible"):
+        zarr.create_array(
+            store=tmp_path / "bad.zarr",
             shape=(120, 100),
             chunks=(10, 10),
-            shards=[[60, 40, 20], [50, 50]],
-            dtype="float64",
+            shards=[[60, 45, 15], [50, 50]],
+            dtype="int32",
         )
-        arr[:] = data
-        # Read a slice crossing shard boundaries
-        result = arr[50:70, 40:60]
-        np.testing.assert_array_equal(result, data[50:70, 40:60])
 
-    def test_rectilinear_shards_validates_divisibility(self, tmp_path: Path) -> None:
-        """Inner chunk_shape must divide every shard's dimensions."""
-        with pytest.raises(ValueError, match="divisible"):
-            zarr.create_array(
-                store=tmp_path / "bad.zarr",
-                shape=(120, 100),
-                chunks=(10, 10),
-                shards=[[60, 45, 15], [50, 50]],  # 45 not divisible by 10
-                dtype="int32",
-            )
 
-    def test_nchunks(self, tmp_path: Path) -> None:
-        z, _ = self._make_2d(tmp_path)
-        assert z.chunk_grid.get_nchunks() == 12
+def test_pipeline_nchunks(tmp_path: Path) -> None:
+    """Rectilinear array reports the correct total number of chunks"""
+    z, _ = _make_2d(tmp_path)
+    assert z.chunk_grid.get_nchunks() == 12
+
+
+def test_pipeline_parse_chunk_grid_regular_from_dict() -> None:
+    """parse_chunk_grid constructs a regular grid from a metadata dict."""
+    d: dict[str, Any] = {"name": "regular", "configuration": {"chunk_shape": [10, 20]}}
+    meta = parse_chunk_grid_metadata(d)
+    g = ChunkGrid.from_sizes((100, 200), tuple(meta.chunk_shape))
+    assert g.is_regular
+    assert g.chunk_shape == (10, 20)
+    assert g.grid_shape == (10, 10)
+    assert g.get_nchunks() == 100
+
+
+# ---------------------------------------------------------------------------
+# VaryingDimension boundary tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("edges", "extent", "chunk_idx", "expected_data_size"),
+    [
+        ([10, 20, 30], 50, 0, 10),
+        ([10, 20, 30], 50, 1, 20),
+        ([10, 20, 30], 50, 2, 20),
+        ([10, 20, 30], 60, 2, 30),
+        ([10, 20, 30], 31, 0, 10),
+        ([10, 20, 30], 31, 1, 20),
+        ([10, 20, 30], 31, 2, 1),
+    ],
+    ids=[
+        "interior-0",
+        "interior-1",
+        "boundary-clipped",
+        "exact-no-clip",
+        "single-element-boundary-0",
+        "single-element-boundary-1",
+        "single-element-boundary-2",
+    ],
+)
+def test_varying_dimension_boundary_data_size(
+    edges: list[int], extent: int, chunk_idx: int, expected_data_size: int
+) -> None:
+    """VaryingDimension.data_size clips correctly at boundary chunks"""
+    d = VaryingDimension(edges, extent=extent)
+    assert d.data_size(chunk_idx) == expected_data_size
+
+
+def test_varying_dimension_boundary_extent_parameter() -> None:
+    """VaryingDimension preserves extent and full chunk_size even when extent < sum of edges"""
+    d = VaryingDimension([10, 20, 30], extent=50)
+    assert d.extent == 50
+    assert d.chunk_size(2) == 30
+
+
+def test_varying_dimension_extent_exceeds_sum_rejected() -> None:
+    """VaryingDimension rejects extent greater than sum of edges"""
+    with pytest.raises(ValueError, match="exceeds sum of edges"):
+        VaryingDimension([10, 20], extent=50)
+
+
+def test_varying_dimension_negative_extent_rejected() -> None:
+    """VaryingDimension rejects negative extent"""
+    with pytest.raises(ValueError, match="must be >= 0"):
+        VaryingDimension([10, 20], extent=-1)
+
+
+def test_varying_dimension_boundary_chunk_spec() -> None:
+    """ChunkGrid with a boundary VaryingDimension produces correct ChunkSpec."""
+    g = ChunkGrid(dimensions=(VaryingDimension([10, 20, 30], extent=50),))
+    spec = g[(2,)]
+    assert spec is not None
+    assert spec.codec_shape == (30,)
+    assert spec.shape == (20,)
+    assert spec.is_boundary is True
+
+
+def test_varying_dimension_interior_chunk_spec() -> None:
+    """Interior VaryingDimension chunk has matching codec_shape and shape with no boundary"""
+    g = ChunkGrid(dimensions=(VaryingDimension([10, 20, 30], extent=50),))
+    spec = g[(0,)]
+    assert spec is not None
+    assert spec.codec_shape == (10,)
+    assert spec.shape == (10,)
+    assert spec.is_boundary is False
+
+
+# ---------------------------------------------------------------------------
+# Multiple overflow chunks tests
+# ---------------------------------------------------------------------------
+
+
+def test_overflow_multiple_chunks_past_extent() -> None:
+    """Edges past extent are structural; nchunks counts active only."""
+    g = ChunkGrid.from_sizes((50,), [[10, 20, 30, 40]])
+    d = g.dimensions[0]
+    assert d.ngridcells == 4
+    assert d.nchunks == 3
+    assert d.data_size(0) == 10
+    assert d.data_size(1) == 20
+    assert d.data_size(2) == 20
+    assert d.chunk_size(2) == 30
+
+
+def test_overflow_chunk_spec_past_extent_is_oob() -> None:
+    """Chunk entirely past the extent is out of bounds (not active)."""
+    g = ChunkGrid.from_sizes((50,), [[10, 20, 30, 40]])
+    spec = g[(3,)]
+    assert spec is None
+
+
+def test_overflow_chunk_spec_partial() -> None:
+    """ChunkSpec for a partially-overflowing chunk clips correctly."""
+    g = ChunkGrid.from_sizes((50,), [[10, 20, 30, 40]])
+    spec = g[(2,)]
+    assert spec is not None
+    assert spec.shape == (20,)
+    assert spec.codec_shape == (30,)
+    assert spec.is_boundary is True
+    assert spec.slices == (slice(30, 50, 1),)
+
+
+def test_overflow_chunk_sizes() -> None:
+    """chunk_sizes only includes active chunks."""
+    g = ChunkGrid.from_sizes((50,), [[10, 20, 30, 40]])
+    assert g.chunk_sizes == ((10, 20, 20),)
+
+
+def test_overflow_multidim() -> None:
+    """Overflow in multiple dimensions simultaneously."""
+    g = ChunkGrid.from_sizes((45, 100), [[10, 20, 30], [40, 40, 40]])
+    assert g.chunk_sizes == ((10, 20, 15), (40, 40, 20))
+    spec = g[(2, 2)]
+    assert spec is not None
+    assert spec.shape == (15, 20)
+    assert spec.codec_shape == (30, 40)
+
+
+def test_overflow_uniform_edges_collapses_to_fixed() -> None:
+    """Uniform edges where len == ceildiv(extent, edge) collapse to FixedDimension."""
+    g = ChunkGrid.from_sizes((35,), [[10, 10, 10, 10]])
+    assert isinstance(g.dimensions[0], FixedDimension)
+    assert g.is_regular
+    assert g.chunk_sizes == ((10, 10, 10, 5),)
+    assert g.dimensions[0].nchunks == 4
+
+
+def test_overflow_serialization_roundtrip() -> None:
+    """Overflow chunks survive serialization round-trip."""
+    g = ChunkGrid.from_sizes((50,), [[10, 20, 30, 40]])
+    serialized = _serialize_via_dto(g)
+    assert serialized["name"] == "rectilinear"
+    config = serialized["configuration"]
+    assert config["kind"] == "inline"
+    assert list(config["chunk_shapes"][0]) == [10, 20, 30, 40]
+    meta = parse_chunk_grid_metadata(serialized)
+    g2 = ChunkGrid.from_sizes((50,), meta.chunk_shapes)
+    assert g2.dimensions[0].ngridcells == 4
+    assert g2.dimensions[0].nchunks == 3
+    assert g2.chunk_sizes == ((10, 20, 20),)
+
+
+def test_overflow_index_to_chunk_near_extent() -> None:
+    """Index lookup near and at the extent boundary."""
+    d = VaryingDimension([10, 20, 30, 40], extent=50)
+    assert d.index_to_chunk(29) == 1
+    assert d.index_to_chunk(30) == 2
+    assert d.index_to_chunk(49) == 2
+
+
+# ---------------------------------------------------------------------------
+# Boundary indexing tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    (
+        "dim",
+        "mask",
+        "dim_len",
+        "expected_chunk_ix",
+        "expected_sel_len",
+        "expected_first_two",
+        "expected_third",
+    ),
+    [
+        (
+            FixedDimension(size=5, extent=7),
+            np.array([False, False, False, False, False, True, True]),
+            7,
+            1,
+            5,
+            (np.True_, np.True_),
+            np.False_,
+        ),
+        (
+            VaryingDimension([5, 10], extent=7),
+            np.array([False, False, False, False, False, True, True]),
+            7,
+            1,
+            10,
+            (np.True_, np.True_),
+            np.False_,
+        ),
+    ],
+    ids=["fixed-boundary", "varying-boundary"],
+)
+def test_bool_indexer_boundary(
+    dim: FixedDimension | VaryingDimension,
+    mask: np.ndarray[Any, Any],
+    dim_len: int,
+    expected_chunk_ix: int,
+    expected_sel_len: int,
+    expected_first_two: tuple[Any, Any],
+    expected_third: Any,
+) -> None:
+    """BoolArrayDimIndexer pads to codec size for boundary chunks."""
+    from zarr.core.indexing import BoolArrayDimIndexer
+
+    indexer = BoolArrayDimIndexer(mask, dim_len, dim)
+    projections = list(indexer)
+    assert len(projections) == 1
+    p = projections[0]
+    assert p.dim_chunk_ix == expected_chunk_ix
+    sel = p.dim_chunk_sel
+    assert isinstance(sel, np.ndarray)
+    assert sel.shape[0] == expected_sel_len
+    assert sel[0] is expected_first_two[0]
+    assert sel[1] is expected_first_two[1]
+    assert sel[2] is expected_third
+
+
+def test_bool_indexer_no_padding_interior() -> None:
+    """No padding needed for interior chunks."""
+    from zarr.core.indexing import BoolArrayDimIndexer
+
+    dim = FixedDimension(size=5, extent=10)
+    mask = np.array([True, False, False, False, False, False, False, False, False, False])
+    indexer = BoolArrayDimIndexer(mask, 10, dim)
+    projections = list(indexer)
+    assert len(projections) == 1
+    p = projections[0]
+    assert p.dim_chunk_ix == 0
+    sel = p.dim_chunk_sel
+    assert isinstance(sel, np.ndarray)
+    assert sel.shape[0] == 5
+
+
+def test_slice_indexer_varying_boundary() -> None:
+    """SliceDimIndexer clips to data_size at boundary for VaryingDimension."""
+    from zarr.core.indexing import SliceDimIndexer
+
+    dim = VaryingDimension([5, 10], extent=7)
+    indexer = SliceDimIndexer(slice(None), 7, dim)
+    projections = list(indexer)
+    assert len(projections) == 2
+    assert projections[0].dim_chunk_sel == slice(0, 5, 1)
+    assert projections[1].dim_chunk_sel == slice(0, 2, 1)
+
+
+def test_int_array_indexer_varying_boundary() -> None:
+    """IntArrayDimIndexer handles indices near boundary correctly."""
+    from zarr.core.indexing import IntArrayDimIndexer
+
+    dim = VaryingDimension([5, 10], extent=7)
+    indices = np.array([6])
+    indexer = IntArrayDimIndexer(indices, 7, dim)
+    projections = list(indexer)
+    assert len(projections) == 1
+    assert projections[0].dim_chunk_ix == 1
+    sel = projections[0].dim_chunk_sel
+    assert isinstance(sel, np.ndarray)
+    np.testing.assert_array_equal(sel, [1])
+
+
+@pytest.mark.parametrize(
+    "dim",
+    [FixedDimension(size=2, extent=10), VaryingDimension([5, 5], extent=10)],
+    ids=["fixed", "varying"],
+)
+def test_slice_indexer_empty_slice_at_boundary(dim: FixedDimension | VaryingDimension) -> None:
+    """SliceDimIndexer yields no projections for an empty slice at the dimension boundary."""
+    from zarr.core.indexing import SliceDimIndexer
+
+    indexer = SliceDimIndexer(slice(10, 10), 10, dim)
+    projections = list(indexer)
+    assert len(projections) == 0
+
+
+def test_orthogonal_indexer_varying_boundary_advanced() -> None:
+    """OrthogonalIndexer with advanced indexing uses per-chunk chunk_size."""
+    from zarr.core.indexing import OrthogonalIndexer
+
+    g = ChunkGrid(
+        dimensions=(
+            VaryingDimension([5, 10], extent=7),
+            FixedDimension(size=4, extent=8),
+        )
+    )
+    indexer = OrthogonalIndexer(
+        selection=(np.array([0, 6]), slice(None)),
+        shape=(7, 8),
+        chunk_grid=g,
+    )
+    projections = list(indexer)
+    assert len(projections) == 4
+    coords = {p.chunk_coords for p in projections}
+    assert coords == {(0, 0), (0, 1), (1, 0), (1, 1)}
+
+
+# ---------------------------------------------------------------------------
+# update_shape tests
+# ---------------------------------------------------------------------------
+
+
+def test_update_shape_no_change() -> None:
+    """update_shape with the same shape preserves edges unchanged"""
+    grid = ChunkGrid.from_sizes((60, 50), [[10, 20, 30], [25, 25]])
+    new_grid = grid.update_shape((60, 50))
+    assert _edges(new_grid, 0) == (10, 20, 30)
+    assert _edges(new_grid, 1) == (25, 25)
+
+
+def test_update_shape_grow_single_dim() -> None:
+    """Growing a single dimension appends a new edge chunk"""
+    grid = ChunkGrid.from_sizes((60, 50), [[10, 20, 30], [25, 25]])
+    new_grid = grid.update_shape((80, 50))
+    assert _edges(new_grid, 0) == (10, 20, 30, 20)
+    assert _edges(new_grid, 1) == (25, 25)
+
+
+def test_update_shape_grow_multiple_dims() -> None:
+    """Growing multiple dimensions appends correctly sized edge chunks"""
+    grid = ChunkGrid.from_sizes((30, 50), [[10, 20], [20, 30]])
+    new_grid = grid.update_shape((45, 65))
+    assert _edges(new_grid, 0) == (10, 20, 15)
+    assert _edges(new_grid, 1) == (20, 30, 15)
+
+
+def test_update_shape_shrink_single_dim() -> None:
+    """Shrinking a single dimension reduces nchunks while preserving edges"""
+    grid = ChunkGrid.from_sizes((100, 50), [[10, 20, 30, 40], [25, 25]])
+    new_grid = grid.update_shape((35, 50))
+    assert _edges(new_grid, 0) == (10, 20, 30, 40)
+    assert new_grid.dimensions[0].nchunks == 3
+    assert _edges(new_grid, 1) == (25, 25)
+
+
+def test_update_shape_shrink_to_single_chunk() -> None:
+    """Shrinking to fit within the first chunk reduces nchunks to 1"""
+    grid = ChunkGrid.from_sizes((60, 50), [[10, 20, 30], [25, 25]])
+    new_grid = grid.update_shape((5, 50))
+    assert _edges(new_grid, 0) == (10, 20, 30)
+    assert new_grid.dimensions[0].nchunks == 1
+    assert _edges(new_grid, 1) == (25, 25)
+
+
+def test_update_shape_shrink_multiple_dims() -> None:
+    """Shrinking multiple dimensions reduces nchunks in each dimension"""
+    grid = ChunkGrid.from_sizes((40, 60), [[10, 10, 15, 5], [20, 25, 15]])
+    new_grid = grid.update_shape((25, 35))
+    assert _edges(new_grid, 0) == (10, 10, 15, 5)
+    assert new_grid.dimensions[0].nchunks == 3
+    assert _edges(new_grid, 1) == (20, 25, 15)
+    assert new_grid.dimensions[1].nchunks == 2
+
+
+def test_update_shape_dimension_mismatch_error() -> None:
+    """update_shape raises ValueError when new shape has different ndim"""
+    grid = ChunkGrid.from_sizes((30, 70), [[10, 20], [30, 40]])
+    with pytest.raises(ValueError, match="dimensions"):
+        grid.update_shape((30, 70, 100))
+
+
+def test_update_shape_boundary_cases() -> None:
+    """update_shape handles grow-one-dim and shrink-both-dims edge cases correctly"""
+    grid = ChunkGrid.from_sizes((60, 40), [[10, 20, 30], [15, 25]])
+    new_grid = grid.update_shape((60, 65))
+    assert _edges(new_grid, 0) == (10, 20, 30)
+    assert _edges(new_grid, 1) == (15, 25, 25)
+
+    grid2 = ChunkGrid.from_sizes((60, 50), [[10, 20, 30], [15, 25, 10]])
+    new_grid2 = grid2.update_shape((30, 40))
+    assert _edges(new_grid2, 0) == (10, 20, 30)
+    assert new_grid2.dimensions[0].nchunks == 2
+    assert _edges(new_grid2, 1) == (15, 25, 10)
+    assert new_grid2.dimensions[1].nchunks == 2
+
+
+def test_update_shape_regular_preserves_extents(tmp_path: Path) -> None:
+    """Resize a regular array -- chunk_grid extents must match new shape."""
+    z = zarr.create_array(
+        store=tmp_path / "regular.zarr",
+        shape=(100,),
+        chunks=(10,),
+        dtype="int32",
+    )
+    z[:] = np.arange(100, dtype="int32")
+    z.resize(50)
+    assert z.shape == (50,)
+    assert z.chunk_grid.dimensions[0].extent == 50
+
+
+# ---------------------------------------------------------------------------
+# update_shape boundary tests
+# ---------------------------------------------------------------------------
+
+
+def test_update_shape_shrink_creates_boundary() -> None:
+    """Shrinking extent into a chunk creates a boundary with clipped data_size"""
+    grid = ChunkGrid.from_sizes((60,), [[10, 20, 30]])
+    new_grid = grid.update_shape((45,))
+    dim = new_grid.dimensions[0]
+    assert isinstance(dim, VaryingDimension)
+    assert dim.edges == (10, 20, 30)
+    assert dim.extent == 45
+    assert dim.chunk_size(2) == 30
+    assert dim.data_size(2) == 15
+
+
+def test_update_shape_shrink_to_exact_boundary() -> None:
+    """Shrinking to an exact chunk boundary reduces nchunks without partial data"""
+    grid = ChunkGrid.from_sizes((60,), [[10, 20, 30]])
+    new_grid = grid.update_shape((30,))
+    dim = new_grid.dimensions[0]
+    assert isinstance(dim, VaryingDimension)
+    assert dim.edges == (10, 20, 30)
+    assert dim.nchunks == 2
+    assert dim.ngridcells == 3
+    assert dim.extent == 30
+    assert dim.data_size(1) == 20
+
+
+def test_update_shape_shrink_chunk_spec() -> None:
+    """After shrink, ChunkSpec reflects boundary correctly."""
+    grid = ChunkGrid.from_sizes((60,), [[10, 20, 30]])
+    new_grid = grid.update_shape((45,))
+    spec = new_grid[(2,)]
+    assert spec is not None
+    assert spec.codec_shape == (30,)
+    assert spec.shape == (15,)
+    assert spec.is_boundary is True
+
+
+def test_update_shape_parse_chunk_grid_rebinds_extent() -> None:
+    """parse_chunk_grid re-binds VaryingDimension extent to array shape."""
+    g = ChunkGrid.from_sizes((60,), [[10, 20, 30]])
+    g2 = ChunkGrid(
+        dimensions=tuple(dim.with_extent(ext) for dim, ext in zip(g.dimensions, (50,), strict=True))
+    )
+    dim = g2.dimensions[0]
+    assert isinstance(dim, VaryingDimension)
+    assert dim.extent == 50
+    assert dim.data_size(2) == 20
+
+
+# ---------------------------------------------------------------------------
+# Resize rectilinear tests
+# ---------------------------------------------------------------------------
+
+
+async def test_async_resize_grow() -> None:
+    """Async resize grow appends new edge chunks and preserves existing data"""
+    store = zarr.storage.MemoryStore()
+    arr = await zarr.api.asynchronous.create_array(
+        store=store,
+        shape=(30, 40),
+        chunks=[[10, 20], [20, 20]],
+        dtype="i4",
+        zarr_format=3,
+    )
+    data = np.arange(30 * 40, dtype="i4").reshape(30, 40)
+    await arr.setitem(slice(None), data)
+
+    await arr.resize((50, 60))
+    assert arr.shape == (50, 60)
+    assert _edges(arr.chunk_grid, 0) == (10, 20, 20)
+    assert _edges(arr.chunk_grid, 1) == (20, 20, 20)
+    result = await arr.getitem((slice(0, 30), slice(0, 40)))
+    np.testing.assert_array_equal(result, data)
+
+
+async def test_async_resize_shrink() -> None:
+    """Async resize shrink truncates data to the new shape"""
+    store = zarr.storage.MemoryStore()
+    arr = await zarr.api.asynchronous.create_array(
+        store=store,
+        shape=(60, 50),
+        chunks=[[10, 20, 30], [25, 25]],
+        dtype="f4",
+        zarr_format=3,
+    )
+    data = np.arange(60 * 50, dtype="f4").reshape(60, 50)
+    await arr.setitem(slice(None), data)
+
+    await arr.resize((25, 30))
+    assert arr.shape == (25, 30)
+    result = await arr.getitem(slice(None))
+    np.testing.assert_array_equal(result, data[:25, :30])
+
+
+def test_sync_resize_grow() -> None:
+    """Sync resize grow expands the array and preserves existing data"""
+    store = zarr.storage.MemoryStore()
+    arr = zarr.create_array(
+        store=store,
+        shape=(20, 30),
+        chunks=[[8, 12], [10, 20]],
+        dtype="u1",
+        zarr_format=3,
+    )
+    data = np.arange(20 * 30, dtype="u1").reshape(20, 30)
+    arr[:] = data
+    arr.resize((35, 45))
+    assert arr.shape == (35, 45)
+    np.testing.assert_array_equal(arr[:20, :30], data)
+
+
+def test_sync_resize_shrink() -> None:
+    """Sync resize shrink truncates the array and returns correct data"""
+    store = zarr.storage.MemoryStore()
+    arr = zarr.create_array(
+        store=store,
+        shape=(40, 50),
+        chunks=[[10, 15, 15], [20, 30]],
+        dtype="i2",
+        zarr_format=3,
+    )
+    data = np.arange(40 * 50, dtype="i2").reshape(40, 50)
+    arr[:] = data
+    arr.resize((15, 30))
+    assert arr.shape == (15, 30)
+    np.testing.assert_array_equal(arr[:], data[:15, :30])
+
+
+# ---------------------------------------------------------------------------
+# Append rectilinear tests
+# ---------------------------------------------------------------------------
+
+
+async def test_append_first_axis() -> None:
+    """Appending along axis 0 grows the array and concatenates data correctly"""
+    store = zarr.storage.MemoryStore()
+    arr = await zarr.api.asynchronous.create_array(
+        store=store,
+        shape=(30, 20),
+        chunks=[[10, 20], [10, 10]],
+        dtype="i4",
+        zarr_format=3,
+    )
+    initial = np.arange(30 * 20, dtype="i4").reshape(30, 20)
+    await arr.setitem(slice(None), initial)
+
+    append_data = np.arange(30 * 20, 45 * 20, dtype="i4").reshape(15, 20)
+    await arr.append(append_data, axis=0)
+    assert arr.shape == (45, 20)
+
+    result = await arr.getitem(slice(None))
+    np.testing.assert_array_equal(result, np.vstack([initial, append_data]))
+
+
+async def test_append_second_axis() -> None:
+    """Appending along axis 1 grows the array and concatenates data correctly"""
+    store = zarr.storage.MemoryStore()
+    arr = await zarr.api.asynchronous.create_array(
+        store=store,
+        shape=(20, 30),
+        chunks=[[10, 10], [10, 20]],
+        dtype="f4",
+        zarr_format=3,
+    )
+    initial = np.arange(20 * 30, dtype="f4").reshape(20, 30)
+    await arr.setitem(slice(None), initial)
+
+    append_data = np.arange(20 * 30, 20 * 45, dtype="f4").reshape(20, 15)
+    await arr.append(append_data, axis=1)
+    assert arr.shape == (20, 45)
+
+    result = await arr.getitem(slice(None))
+    np.testing.assert_array_equal(result, np.hstack([initial, append_data]))
+
+
+def test_sync_append() -> None:
+    """Sync append grows the array and preserves both initial and appended data"""
+    store = zarr.storage.MemoryStore()
+    arr = zarr.create_array(
+        store=store,
+        shape=(20, 20),
+        chunks=[[8, 12], [7, 13]],
+        dtype="u2",
+        zarr_format=3,
+    )
+    initial = np.arange(20 * 20, dtype="u2").reshape(20, 20)
+    arr[:] = initial
+
+    append_data = np.arange(20 * 20, 25 * 20, dtype="u2").reshape(5, 20)
+    arr.append(append_data, axis=0)
+    assert arr.shape == (25, 20)
+    np.testing.assert_array_equal(arr[:20, :], initial)
+    np.testing.assert_array_equal(arr[20:, :], append_data)
+
+
+async def test_multiple_appends() -> None:
+    """Multiple sequential appends accumulate data correctly"""
+    store = zarr.storage.MemoryStore()
+    arr = await zarr.api.asynchronous.create_array(
+        store=store,
+        shape=(10, 10),
+        chunks=[[3, 7], [4, 6]],
+        dtype="i4",
+        zarr_format=3,
+    )
+    initial = np.arange(10 * 10, dtype="i4").reshape(10, 10)
+    await arr.setitem(slice(None), initial)
+
+    all_data = [initial]
+    for i in range(3):
+        chunk = np.full((5, 10), i + 100, dtype="i4")
+        await arr.append(chunk, axis=0)
+        all_data.append(chunk)
+
+    assert arr.shape == (25, 10)
+    result = await arr.getitem(slice(None))
+    np.testing.assert_array_equal(result, np.vstack(all_data))
+
+
+async def test_append_with_partial_edge_chunks() -> None:
+    """Appending data that creates partial edge chunks preserves all data"""
+    store = zarr.storage.MemoryStore()
+    arr = await zarr.api.asynchronous.create_array(
+        store=store,
+        shape=(25, 30),
+        chunks=[[10, 15], [12, 18]],
+        dtype="f8",
+        zarr_format=3,
+    )
+    initial = np.random.default_rng(42).random((25, 30))
+    await arr.setitem(slice(None), initial)
+
+    append_data = np.random.default_rng(43).random((10, 30))
+    await arr.append(append_data, axis=0)
+    assert arr.shape == (35, 30)
+
+    result = np.asarray(await arr.getitem(slice(None)))
+    np.testing.assert_array_almost_equal(result, np.vstack([initial, append_data]))
+
+
+async def test_append_small_data() -> None:
+    """Appending a small amount of data smaller than a chunk works correctly"""
+    store = zarr.storage.MemoryStore()
+    arr = await zarr.api.asynchronous.create_array(
+        store=store,
+        shape=(20, 20),
+        chunks=[[8, 12], [7, 13]],
+        dtype="i4",
+        zarr_format=3,
+    )
+    data = np.arange(20 * 20, dtype="i4").reshape(20, 20)
+    await arr.setitem(slice(None), data)
+
+    small = np.full((3, 20), 999, dtype="i4")
+    await arr.append(small, axis=0)
+    assert arr.shape == (23, 20)
+    result = await arr.getitem((slice(20, 23), slice(None)))
+    np.testing.assert_array_equal(result, small)
+
+
+# ---------------------------------------------------------------------------
+# V2 regression tests
+# ---------------------------------------------------------------------------
+
+
+def test_v2_create_and_readback(tmp_path: Path) -> None:
+    """Basic V2 array: create, write, read back."""
+    data = np.arange(60, dtype="float64").reshape(6, 10)
+    a = zarr.create_array(
+        store=tmp_path / "v2.zarr",
+        shape=data.shape,
+        chunks=(3, 5),
+        dtype=data.dtype,
+        zarr_format=2,
+    )
+    a[:] = data
+    np.testing.assert_array_equal(a[:], data)
+
+
+def test_v2_chunk_grid_is_regular(tmp_path: Path) -> None:
+    """V2 chunk_grid produces a regular ChunkGrid with FixedDimensions."""
+    a = zarr.create_array(
+        store=tmp_path / "v2.zarr",
+        shape=(20, 30),
+        chunks=(10, 15),
+        dtype="int32",
+        zarr_format=2,
+    )
+    grid = a.chunk_grid
+    assert grid.is_regular
+    assert grid.chunk_shape == (10, 15)
+    assert grid.grid_shape == (2, 2)
+    assert all(isinstance(d, FixedDimension) for d in grid.dimensions)
+
+
+def test_v2_boundary_chunks(tmp_path: Path) -> None:
+    """V2 boundary chunks: codec buffer size stays full, data is clipped."""
+    a = zarr.create_array(
+        store=tmp_path / "v2.zarr",
+        shape=(25,),
+        chunks=(10,),
+        dtype="int32",
+        zarr_format=2,
+    )
+    grid = a.chunk_grid
+    assert grid.dimensions[0].nchunks == 3
+    assert grid.dimensions[0].chunk_size(2) == 10
+    assert grid.dimensions[0].data_size(2) == 5
+
+
+def test_v2_slicing_with_boundary(tmp_path: Path) -> None:
+    """V2 array slicing across boundary chunks returns correct data."""
+    data = np.arange(25, dtype="int32")
+    a = zarr.create_array(
+        store=tmp_path / "v2.zarr",
+        shape=(25,),
+        chunks=(10,),
+        dtype="int32",
+        zarr_format=2,
+    )
+    a[:] = data
+    np.testing.assert_array_equal(a[18:25], data[18:25])
+    np.testing.assert_array_equal(a[:], data)
+
+
+def test_v2_metadata_roundtrip(tmp_path: Path) -> None:
+    """V2 metadata survives store close and reopen."""
+    store_path = tmp_path / "v2.zarr"
+    data = np.arange(12, dtype="float32").reshape(3, 4)
+    a = zarr.create_array(
+        store=store_path,
+        shape=data.shape,
+        chunks=(2, 2),
+        dtype=data.dtype,
+        zarr_format=2,
+    )
+    a[:] = data
+
+    b = zarr.open_array(store=store_path, mode="r")
+    assert b.metadata.zarr_format == 2
+    assert b.chunks == (2, 2)
+    assert b.chunk_grid.chunk_shape == (2, 2)
+    np.testing.assert_array_equal(b[:], data)
+
+
+def test_v2_chunk_spec_via_grid(tmp_path: Path) -> None:
+    """ChunkSpec from V2 grid has correct slices and codec_shape."""
+    a = zarr.create_array(
+        store=tmp_path / "v2.zarr",
+        shape=(15, 20),
+        chunks=(10, 10),
+        dtype="int32",
+        zarr_format=2,
+    )
+    grid = a.chunk_grid
+    spec = grid[(0, 0)]
+    assert spec is not None
+    assert spec.shape == (10, 10)
+    assert spec.codec_shape == (10, 10)
+    spec = grid[(1, 1)]
+    assert spec is not None
+    assert spec.shape == (5, 10)
+    assert spec.codec_shape == (10, 10)
+
+
+# ---------------------------------------------------------------------------
+# ChunkSizes tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("shape", "chunks", "expected"),
+    [
+        ((100, 80), (30, 40), ((30, 30, 30, 10), (40, 40))),
+        ((90, 80), (30, 40), ((30, 30, 30), (40, 40))),
+        ((60, 100), [[10, 20, 30], [50, 50]], ((10, 20, 30), (50, 50))),
+        ((10,), (10,), ((10,),)),
+    ],
+    ids=["regular", "regular-exact", "rectilinear", "single-chunk"],
+)
+def test_chunk_sizes(
+    shape: tuple[int, ...], chunks: Any, expected: tuple[tuple[int, ...], ...]
+) -> None:
+    """chunk_sizes returns the per-dimension tuple of actual data sizes"""
+    grid = ChunkGrid.from_sizes(shape, chunks)
+    assert grid.chunk_sizes == expected
+
+
+def test_array_read_chunk_sizes_regular() -> None:
+    """Regular array exposes correct read_chunk_sizes and write_chunk_sizes"""
+    store = zarr.storage.MemoryStore()
+    arr = zarr.create_array(
+        store=store, shape=(100, 80), chunks=(30, 40), dtype="i4", zarr_format=3
+    )
+    assert arr.read_chunk_sizes == ((30, 30, 30, 10), (40, 40))
+    assert arr.write_chunk_sizes == ((30, 30, 30, 10), (40, 40))
+
+
+def test_array_read_chunk_sizes_rectilinear() -> None:
+    """Rectilinear array exposes correct read_chunk_sizes and write_chunk_sizes"""
+    store = zarr.storage.MemoryStore()
+    arr = zarr.create_array(
+        store=store, shape=(60, 100), chunks=[[10, 20, 30], [50, 50]], dtype="i4", zarr_format=3
+    )
+    assert arr.read_chunk_sizes == ((10, 20, 30), (50, 50))
+    assert arr.write_chunk_sizes == ((10, 20, 30), (50, 50))
+
+
+def test_array_sharded_chunk_sizes() -> None:
+    """Sharded array read_chunk_sizes reflects inner chunks and write_chunk_sizes reflects shards"""
+    store = zarr.storage.MemoryStore()
+    arr = zarr.create_array(
+        store=store,
+        shape=(120, 80),
+        chunks=(60, 40),
+        shards=(120, 80),
+        dtype="i4",
+        zarr_format=3,
+    )
+    assert arr.read_chunk_sizes == ((60, 60), (40, 40))
+    assert arr.write_chunk_sizes == ((120,), (80,))
+
+
+# ---------------------------------------------------------------------------
+# Info display test
+# ---------------------------------------------------------------------------
+
+
+def test_info_display_rectilinear() -> None:
+    """Array.info should not crash for rectilinear grids."""
+    store = zarr.storage.MemoryStore()
+    arr = zarr.create_array(
+        store=store,
+        shape=(30,),
+        chunks=[[10, 20]],
+        dtype="i4",
+        zarr_format=3,
+    )
+    info = arr.info
+    text = repr(info)
+    assert "<variable>" in text
+    assert "Array" in text
+
+
+# ---------------------------------------------------------------------------
+# nchunks tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("shape", "chunks", "expected"),
+    [
+        ((30,), [[10, 20]], 2),
+        ((30, 40), [[10, 20], [15, 25]], 4),
+    ],
+    ids=["1d", "2d"],
+)
+def test_nchunks_rectilinear(
+    shape: tuple[int, ...], chunks: list[list[int]], expected: int
+) -> None:
+    """Array.nchunks reports correct total chunk count for rectilinear arrays"""
+    store = MemoryStore()
+    a = zarr.create_array(store, shape=shape, chunks=chunks, dtype="int32")
+    assert a.nchunks == expected
+
+
+# ---------------------------------------------------------------------------
+# iter_chunk_regions test
+# ---------------------------------------------------------------------------
+
+
+def test_iter_chunk_regions_rectilinear() -> None:
+    """_iter_chunk_regions should work for rectilinear arrays."""
+    from zarr.core.array import _iter_chunk_regions
+
+    store = MemoryStore()
+    a = zarr.create_array(store, shape=(30,), chunks=[[10, 20]], dtype="int32")
+    regions = list(_iter_chunk_regions(a))
+    assert len(regions) == 2
+    assert regions[0] == (slice(0, 10, 1),)
+    assert regions[1] == (slice(10, 30, 1),)
+
+
+# ---------------------------------------------------------------------------
+# RectilinearChunkGrid metadata object tests (already parametrized)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("json_input", "expected_chunk_shapes"),
+    [
+        (
+            {
+                "name": "rectilinear",
+                "configuration": {"kind": "inline", "chunk_shapes": [4, 8]},
+            },
+            (4, 8),
+        ),
+        (
+            {
+                "name": "rectilinear",
+                "configuration": {"kind": "inline", "chunk_shapes": [[1, 2, 3], [10, 20]]},
+            },
+            ((1, 2, 3), (10, 20)),
+        ),
+        (
+            {
+                "name": "rectilinear",
+                "configuration": {"kind": "inline", "chunk_shapes": [[[4, 3]], [10, 20]]},
+            },
+            ((4, 4, 4), (10, 20)),
+        ),
+        (
+            {
+                "name": "rectilinear",
+                "configuration": {"kind": "inline", "chunk_shapes": [[[1, 3], 3], [5]]},
+            },
+            ((1, 1, 1, 3), (5,)),
+        ),
+        (
+            {
+                "name": "rectilinear",
+                "configuration": {"kind": "inline", "chunk_shapes": [4, [10, 20]]},
+            },
+            (4, (10, 20)),
+        ),
+    ],
+)
+def test_rectilinear_from_dict(
+    json_input: dict[str, Any], expected_chunk_shapes: tuple[int | tuple[int, ...], ...]
+) -> None:
+    """RectilinearChunkGrid.from_dict correctly parses all spec forms."""
+    grid = RectilinearChunkGrid.from_dict(json_input)
+    assert grid.chunk_shapes == expected_chunk_shapes
+
+
+@pytest.mark.parametrize(
+    ("chunk_shapes", "expected_json_shapes"),
+    [
+        ((4, 8), [4, 8]),
+        (((4,), (8,)), [[4], [8]]),
+        (((10, 20), (5, 5)), [[10, 20], [[5, 2]]]),
+        (((4, 4, 4), (10, 20)), [[[4, 3]], [10, 20]]),
+        ((4, (10, 20)), [4, [10, 20]]),
+    ],
+)
+def test_rectilinear_to_dict(
+    chunk_shapes: tuple[int | tuple[int, ...], ...],
+    expected_json_shapes: list[Any],
+) -> None:
+    """RectilinearChunkGrid.to_dict serializes back to spec-compliant JSON."""
+    grid = RectilinearChunkGrid(chunk_shapes=chunk_shapes)
+    result = grid.to_dict()
+    assert result["name"] == "rectilinear"
+    assert result["configuration"]["kind"] == "inline"
+    assert list(result["configuration"]["chunk_shapes"]) == expected_json_shapes
+
+
+@pytest.mark.parametrize(
+    "json_input",
+    [
+        {"name": "rectilinear", "configuration": {"kind": "inline", "chunk_shapes": [4, 8]}},
+        {
+            "name": "rectilinear",
+            "configuration": {"kind": "inline", "chunk_shapes": [[1, 2, 3], [10, 20]]},
+        },
+        {
+            "name": "rectilinear",
+            "configuration": {"kind": "inline", "chunk_shapes": [[[4, 3]], [[5, 2]]]},
+        },
+    ],
+)
+def test_rectilinear_roundtrip(json_input: dict[str, Any]) -> None:
+    """from_dict -> to_dict -> from_dict produces the same grid."""
+    grid1 = RectilinearChunkGrid.from_dict(json_input)
+    grid2 = RectilinearChunkGrid.from_dict(grid1.to_dict())
+    assert grid1.chunk_shapes == grid2.chunk_shapes
+
+
+# ---------------------------------------------------------------------------
+# Hypothesis property tests
+# ---------------------------------------------------------------------------
 
 
 pytest.importorskip("hypothesis")
@@ -1865,7 +2974,6 @@ def test_property_block_indexing_rectilinear(data: st.DataObject) -> None:
     z, a = data.draw(rectilinear_arrays_st())
     grid = z.chunk_grid
 
-    # Pick a random block per dimension and verify it matches the expected slice
     for dim in range(a.ndim):
         dim_grid = grid.dimensions[dim]
         block_ix = data.draw(st.integers(min_value=0, max_value=dim_grid.nchunks - 1))
@@ -1880,787 +2988,3 @@ def test_property_block_indexing_rectilinear(data: st.DataObject) -> None:
             a[tuple(sel)],
             err_msg=f"dim={dim}, block={block_ix}",
         )
-
-
-class TestV2Regression:
-    """Verify V2 arrays still work correctly after the ChunkGrid refactor.
-
-    V2 only supports regular chunks. These tests ensure the V2 metadata
-    round-trip (create → write → read) and chunk_grid property work as
-    expected with the unified ChunkGrid infrastructure.
-    """
-
-    def test_v2_create_and_readback(self, tmp_path: Path) -> None:
-        """Basic V2 array: create, write, read back."""
-        data = np.arange(60, dtype="float64").reshape(6, 10)
-        a = zarr.create_array(
-            store=tmp_path / "v2.zarr",
-            shape=data.shape,
-            chunks=(3, 5),
-            dtype=data.dtype,
-            zarr_format=2,
-        )
-        a[:] = data
-        np.testing.assert_array_equal(a[:], data)
-
-    def test_v2_chunk_grid_is_regular(self, tmp_path: Path) -> None:
-        """V2 chunk_grid produces a regular ChunkGrid with FixedDimensions."""
-        a = zarr.create_array(
-            store=tmp_path / "v2.zarr",
-            shape=(20, 30),
-            chunks=(10, 15),
-            dtype="int32",
-            zarr_format=2,
-        )
-        grid = a.chunk_grid
-        assert grid.is_regular
-        assert grid.chunk_shape == (10, 15)
-        assert grid.grid_shape == (2, 2)
-        assert all(isinstance(d, FixedDimension) for d in grid.dimensions)
-
-    def test_v2_boundary_chunks(self, tmp_path: Path) -> None:
-        """V2 boundary chunks: codec buffer size stays full, data is clipped."""
-        a = zarr.create_array(
-            store=tmp_path / "v2.zarr",
-            shape=(25,),
-            chunks=(10,),
-            dtype="int32",
-            zarr_format=2,
-        )
-        grid = a.chunk_grid
-        assert grid.dimensions[0].nchunks == 3
-        assert grid.dimensions[0].chunk_size(2) == 10  # full codec buffer
-        assert grid.dimensions[0].data_size(2) == 5  # clipped to extent
-
-    def test_v2_slicing_with_boundary(self, tmp_path: Path) -> None:
-        """V2 array slicing across boundary chunks returns correct data."""
-        data = np.arange(25, dtype="int32")
-        a = zarr.create_array(
-            store=tmp_path / "v2.zarr",
-            shape=(25,),
-            chunks=(10,),
-            dtype="int32",
-            zarr_format=2,
-        )
-        a[:] = data
-        np.testing.assert_array_equal(a[18:25], data[18:25])
-        np.testing.assert_array_equal(a[:], data)
-
-    def test_v2_metadata_roundtrip(self, tmp_path: Path) -> None:
-        """V2 metadata survives store close and reopen."""
-        store_path = tmp_path / "v2.zarr"
-        data = np.arange(12, dtype="float32").reshape(3, 4)
-        a = zarr.create_array(
-            store=store_path,
-            shape=data.shape,
-            chunks=(2, 2),
-            dtype=data.dtype,
-            zarr_format=2,
-        )
-        a[:] = data
-
-        # Reopen from store
-        b = zarr.open_array(store=store_path, mode="r")
-        assert b.metadata.zarr_format == 2
-        assert b.chunks == (2, 2)
-        assert b.chunk_grid.chunk_shape == (2, 2)
-        np.testing.assert_array_equal(b[:], data)
-
-    def test_v2_chunk_spec_via_grid(self, tmp_path: Path) -> None:
-        """ChunkSpec from V2 grid has correct slices and codec_shape."""
-        a = zarr.create_array(
-            store=tmp_path / "v2.zarr",
-            shape=(15, 20),
-            chunks=(10, 10),
-            dtype="int32",
-            zarr_format=2,
-        )
-        grid = a.chunk_grid
-        # Interior chunk
-        spec = grid[(0, 0)]
-        assert spec is not None
-        assert spec.shape == (10, 10)
-        assert spec.codec_shape == (10, 10)
-        # Boundary chunk
-        spec = grid[(1, 1)]
-        assert spec is not None
-        assert spec.shape == (5, 10)  # clipped data
-        assert spec.codec_shape == (10, 10)  # full buffer
-
-
-class TestChunkSizes:
-    """Tests for ChunkGrid.chunk_sizes and Array.read_chunk_sizes / write_chunk_sizes."""
-
-    def test_regular_grid(self) -> None:
-        grid = ChunkGrid.from_regular((100, 80), (30, 40))
-        assert grid.chunk_sizes == ((30, 30, 30, 10), (40, 40))
-
-    def test_regular_grid_exact(self) -> None:
-        grid = ChunkGrid.from_regular((90, 80), (30, 40))
-        assert grid.chunk_sizes == ((30, 30, 30), (40, 40))
-
-    def test_rectilinear_grid(self) -> None:
-        grid = ChunkGrid.from_rectilinear([[10, 20, 30], [50, 50]], array_shape=(60, 100))
-        assert grid.chunk_sizes == ((10, 20, 30), (50, 50))
-
-    def test_single_chunk(self) -> None:
-        grid = ChunkGrid.from_regular((10,), (10,))
-        assert grid.chunk_sizes == ((10,),)
-
-    def test_array_read_chunk_sizes_regular(self) -> None:
-        store = zarr.storage.MemoryStore()
-        arr = zarr.create_array(
-            store=store, shape=(100, 80), chunks=(30, 40), dtype="i4", zarr_format=3
-        )
-        assert arr.read_chunk_sizes == ((30, 30, 30, 10), (40, 40))
-        assert arr.write_chunk_sizes == ((30, 30, 30, 10), (40, 40))
-
-    def test_array_read_chunk_sizes_rectilinear(self) -> None:
-        store = zarr.storage.MemoryStore()
-        arr = zarr.create_array(
-            store=store, shape=(60, 100), chunks=[[10, 20, 30], [50, 50]], dtype="i4", zarr_format=3
-        )
-        assert arr.read_chunk_sizes == ((10, 20, 30), (50, 50))
-        assert arr.write_chunk_sizes == ((10, 20, 30), (50, 50))
-
-    def test_array_sharded_chunk_sizes(self) -> None:
-        store = zarr.storage.MemoryStore()
-        arr = zarr.create_array(
-            store=store,
-            shape=(120, 80),
-            chunks=(60, 40),
-            shards=(120, 80),
-            dtype="i4",
-            zarr_format=3,
-        )
-        # read_chunk_sizes returns inner chunks
-        assert arr.read_chunk_sizes == ((60, 60), (40, 40))
-        # write_chunk_sizes returns outer (shard) chunks
-        assert arr.write_chunk_sizes == ((120,), (80,))
-
-
-def test_info_display_rectilinear() -> None:
-    """Array.info should not crash for rectilinear grids."""
-    store = zarr.storage.MemoryStore()
-    arr = zarr.create_array(
-        store=store,
-        shape=(30,),
-        chunks=[[10, 20]],
-        dtype="i4",
-        zarr_format=3,
-    )
-    info = arr.info
-    text = repr(info)
-    assert "<variable>" in text
-    assert "Array" in text
-
-
-class TestUpdateShape:
-    """Unit tests for ChunkGrid.update_shape()."""
-
-    def test_no_change(self) -> None:
-        grid = ChunkGrid.from_rectilinear([[10, 20, 30], [25, 25]], array_shape=(60, 50))
-        new_grid = grid.update_shape((60, 50))
-        assert _edges(new_grid, 0) == (10, 20, 30)
-        assert _edges(new_grid, 1) == (25, 25)
-
-    def test_grow_single_dim(self) -> None:
-        grid = ChunkGrid.from_rectilinear([[10, 20, 30], [25, 25]], array_shape=(60, 50))
-        new_grid = grid.update_shape((80, 50))
-        assert _edges(new_grid, 0) == (10, 20, 30, 20)
-        assert _edges(new_grid, 1) == (25, 25)
-
-    def test_grow_multiple_dims(self) -> None:
-        grid = ChunkGrid.from_rectilinear([[10, 20], [20, 30]], array_shape=(30, 50))
-        # from (30, 50) to (45, 65)
-        new_grid = grid.update_shape((45, 65))
-        assert _edges(new_grid, 0) == (10, 20, 15)
-        assert _edges(new_grid, 1) == (20, 30, 15)
-
-    def test_shrink_single_dim(self) -> None:
-        grid = ChunkGrid.from_rectilinear([[10, 20, 30, 40], [25, 25]], array_shape=(100, 50))
-        new_grid = grid.update_shape((35, 50))
-        # All edges preserved (spec allows trailing edges beyond extent)
-        assert _edges(new_grid, 0) == (10, 20, 30, 40)
-        # But only 3 chunks are active (10+20+30=60 >= 35)
-        assert new_grid.dimensions[0].nchunks == 3
-        assert _edges(new_grid, 1) == (25, 25)
-
-    def test_shrink_to_single_chunk(self) -> None:
-        grid = ChunkGrid.from_rectilinear([[10, 20, 30], [25, 25]], array_shape=(60, 50))
-        new_grid = grid.update_shape((5, 50))
-        # All edges preserved
-        assert _edges(new_grid, 0) == (10, 20, 30)
-        # But only 1 chunk is active (10 >= 5)
-        assert new_grid.dimensions[0].nchunks == 1
-        assert _edges(new_grid, 1) == (25, 25)
-
-    def test_shrink_multiple_dims(self) -> None:
-        grid = ChunkGrid.from_rectilinear([[10, 10, 15, 5], [20, 25, 15]], array_shape=(40, 60))
-        # from (40, 60) to (25, 35)
-        new_grid = grid.update_shape((25, 35))
-        # All edges preserved, but nchunks reflects active chunks
-        assert _edges(new_grid, 0) == (10, 10, 15, 5)
-        assert new_grid.dimensions[0].nchunks == 3  # 10+10+15=35 >= 25
-        assert _edges(new_grid, 1) == (20, 25, 15)
-        assert new_grid.dimensions[1].nchunks == 2  # 20+25=45 >= 35
-
-    def test_dimension_mismatch_error(self) -> None:
-        grid = ChunkGrid.from_rectilinear([[10, 20], [30, 40]], array_shape=(30, 70))
-        with pytest.raises(ValueError, match="dimensions"):
-            grid.update_shape((30, 70, 100))
-
-    def test_boundary_cases(self) -> None:
-        grid = ChunkGrid.from_rectilinear([[10, 20, 30], [15, 25]], array_shape=(60, 40))
-        # Grow to exact chunk boundary on dim 0, add 25 to dim 1
-        new_grid = grid.update_shape((60, 65))
-        assert _edges(new_grid, 0) == (10, 20, 30)  # no change (60 == sum)
-        assert _edges(new_grid, 1) == (15, 25, 25)  # added chunk of 25
-
-        # Shrink to exact chunk boundary — edges preserved, nchunks adjusts
-        grid2 = ChunkGrid.from_rectilinear([[10, 20, 30], [15, 25, 10]], array_shape=(60, 50))
-        new_grid2 = grid2.update_shape((30, 40))
-        # All edges preserved
-        assert _edges(new_grid2, 0) == (10, 20, 30)
-        assert new_grid2.dimensions[0].nchunks == 2  # 10+20=30 >= 30
-        assert _edges(new_grid2, 1) == (15, 25, 10)
-        assert new_grid2.dimensions[1].nchunks == 2  # 15+25=40 >= 40
-
-    def test_regular_preserves_extents(self, tmp_path: Path) -> None:
-        """Resize a regular array — chunk_grid extents must match new shape."""
-        z = zarr.create_array(
-            store=tmp_path / "regular.zarr",
-            shape=(100,),
-            chunks=(10,),
-            dtype="int32",
-        )
-        z[:] = np.arange(100, dtype="int32")
-        z.resize(50)
-        assert z.shape == (50,)
-        assert z.chunk_grid.dimensions[0].extent == 50
-
-
-class TestResizeRectilinear:
-    """End-to-end resize tests on rectilinear arrays."""
-
-    async def test_async_resize_grow(self) -> None:
-        store = zarr.storage.MemoryStore()
-        arr = await zarr.api.asynchronous.create_array(
-            store=store,
-            shape=(30, 40),
-            chunks=[[10, 20], [20, 20]],
-            dtype="i4",
-            zarr_format=3,
-        )
-        data = np.arange(30 * 40, dtype="i4").reshape(30, 40)
-        await arr.setitem(slice(None), data)
-
-        await arr.resize((50, 60))
-        assert arr.shape == (50, 60)
-        assert _edges(arr.chunk_grid, 0) == (10, 20, 20)
-        assert _edges(arr.chunk_grid, 1) == (20, 20, 20)
-        result = await arr.getitem((slice(0, 30), slice(0, 40)))
-        np.testing.assert_array_equal(result, data)
-
-    async def test_async_resize_shrink(self) -> None:
-        store = zarr.storage.MemoryStore()
-        arr = await zarr.api.asynchronous.create_array(
-            store=store,
-            shape=(60, 50),
-            chunks=[[10, 20, 30], [25, 25]],
-            dtype="f4",
-            zarr_format=3,
-        )
-        data = np.arange(60 * 50, dtype="f4").reshape(60, 50)
-        await arr.setitem(slice(None), data)
-
-        await arr.resize((25, 30))
-        assert arr.shape == (25, 30)
-        result = await arr.getitem(slice(None))
-        np.testing.assert_array_equal(result, data[:25, :30])
-
-    def test_sync_resize_grow(self) -> None:
-        store = zarr.storage.MemoryStore()
-        arr = zarr.create_array(
-            store=store,
-            shape=(20, 30),
-            chunks=[[8, 12], [10, 20]],
-            dtype="u1",
-            zarr_format=3,
-        )
-        data = np.arange(20 * 30, dtype="u1").reshape(20, 30)
-        arr[:] = data
-        arr.resize((35, 45))
-        assert arr.shape == (35, 45)
-        np.testing.assert_array_equal(arr[:20, :30], data)
-
-    def test_sync_resize_shrink(self) -> None:
-        store = zarr.storage.MemoryStore()
-        arr = zarr.create_array(
-            store=store,
-            shape=(40, 50),
-            chunks=[[10, 15, 15], [20, 30]],
-            dtype="i2",
-            zarr_format=3,
-        )
-        data = np.arange(40 * 50, dtype="i2").reshape(40, 50)
-        arr[:] = data
-        arr.resize((15, 30))
-        assert arr.shape == (15, 30)
-        np.testing.assert_array_equal(arr[:], data[:15, :30])
-
-
-class TestAppendRectilinear:
-    """End-to-end append tests on rectilinear arrays."""
-
-    async def test_append_first_axis(self) -> None:
-        store = zarr.storage.MemoryStore()
-        arr = await zarr.api.asynchronous.create_array(
-            store=store,
-            shape=(30, 20),
-            chunks=[[10, 20], [10, 10]],
-            dtype="i4",
-            zarr_format=3,
-        )
-        initial = np.arange(30 * 20, dtype="i4").reshape(30, 20)
-        await arr.setitem(slice(None), initial)
-
-        append_data = np.arange(30 * 20, 45 * 20, dtype="i4").reshape(15, 20)
-        await arr.append(append_data, axis=0)
-        assert arr.shape == (45, 20)
-
-        result = await arr.getitem(slice(None))
-        np.testing.assert_array_equal(result, np.vstack([initial, append_data]))
-
-    async def test_append_second_axis(self) -> None:
-        store = zarr.storage.MemoryStore()
-        arr = await zarr.api.asynchronous.create_array(
-            store=store,
-            shape=(20, 30),
-            chunks=[[10, 10], [10, 20]],
-            dtype="f4",
-            zarr_format=3,
-        )
-        initial = np.arange(20 * 30, dtype="f4").reshape(20, 30)
-        await arr.setitem(slice(None), initial)
-
-        append_data = np.arange(20 * 30, 20 * 45, dtype="f4").reshape(20, 15)
-        await arr.append(append_data, axis=1)
-        assert arr.shape == (20, 45)
-
-        result = await arr.getitem(slice(None))
-        np.testing.assert_array_equal(result, np.hstack([initial, append_data]))
-
-    def test_sync_append(self) -> None:
-        store = zarr.storage.MemoryStore()
-        arr = zarr.create_array(
-            store=store,
-            shape=(20, 20),
-            chunks=[[8, 12], [7, 13]],
-            dtype="u2",
-            zarr_format=3,
-        )
-        initial = np.arange(20 * 20, dtype="u2").reshape(20, 20)
-        arr[:] = initial
-
-        append_data = np.arange(20 * 20, 25 * 20, dtype="u2").reshape(5, 20)
-        arr.append(append_data, axis=0)
-        assert arr.shape == (25, 20)
-        np.testing.assert_array_equal(arr[:20, :], initial)
-        np.testing.assert_array_equal(arr[20:, :], append_data)
-
-    async def test_multiple_appends(self) -> None:
-        store = zarr.storage.MemoryStore()
-        arr = await zarr.api.asynchronous.create_array(
-            store=store,
-            shape=(10, 10),
-            chunks=[[3, 7], [4, 6]],
-            dtype="i4",
-            zarr_format=3,
-        )
-        initial = np.arange(10 * 10, dtype="i4").reshape(10, 10)
-        await arr.setitem(slice(None), initial)
-
-        all_data = [initial]
-        for i in range(3):
-            chunk = np.full((5, 10), i + 100, dtype="i4")
-            await arr.append(chunk, axis=0)
-            all_data.append(chunk)
-
-        assert arr.shape == (25, 10)
-        result = await arr.getitem(slice(None))
-        np.testing.assert_array_equal(result, np.vstack(all_data))
-
-    async def test_append_with_partial_edge_chunks(self) -> None:
-        store = zarr.storage.MemoryStore()
-        arr = await zarr.api.asynchronous.create_array(
-            store=store,
-            shape=(25, 30),
-            chunks=[[10, 15], [12, 18]],
-            dtype="f8",
-            zarr_format=3,
-        )
-        initial = np.random.default_rng(42).random((25, 30))
-        await arr.setitem(slice(None), initial)
-
-        append_data = np.random.default_rng(43).random((10, 30))
-        await arr.append(append_data, axis=0)
-        assert arr.shape == (35, 30)
-
-        result = np.asarray(await arr.getitem(slice(None)))
-        np.testing.assert_array_almost_equal(result, np.vstack([initial, append_data]))
-
-    async def test_append_small_data(self) -> None:
-        store = zarr.storage.MemoryStore()
-        arr = await zarr.api.asynchronous.create_array(
-            store=store,
-            shape=(20, 20),
-            chunks=[[8, 12], [7, 13]],
-            dtype="i4",
-            zarr_format=3,
-        )
-        data = np.arange(20 * 20, dtype="i4").reshape(20, 20)
-        await arr.setitem(slice(None), data)
-
-        small = np.full((3, 20), 999, dtype="i4")
-        await arr.append(small, axis=0)
-        assert arr.shape == (23, 20)
-        result = await arr.getitem((slice(20, 23), slice(None)))
-        np.testing.assert_array_equal(result, small)
-
-    def test_parse_chunk_grid_regular_from_dict(self) -> None:
-        """parse_chunk_grid constructs a regular grid from a metadata dict."""
-        d: dict[str, Any] = {"name": "regular", "configuration": {"chunk_shape": [10, 20]}}
-        g = parse_chunk_grid(d, (100, 200))
-        assert g.is_regular
-        assert g.chunk_shape == (10, 20)
-        assert g.grid_shape == (10, 10)
-        assert g.get_nchunks() == 100
-
-
-class TestVaryingDimensionBoundary:
-    """VaryingDimension with extent < sum(edges), mirroring how FixedDimension
-    handles boundary chunks."""
-
-    def test_extent_parameter(self) -> None:
-        d = VaryingDimension([10, 20, 30], extent=50)
-        assert d.extent == 50
-        assert d.chunk_size(2) == 30
-        assert d.data_size(2) == 20
-
-    def test_extent_equals_sum_no_clipping(self) -> None:
-        d = VaryingDimension([10, 20, 30], extent=60)
-        assert d.extent == 60
-        assert d.data_size(2) == 30
-
-    def test_data_size_interior_chunks_unaffected(self) -> None:
-        d = VaryingDimension([10, 20, 30], extent=50)
-        assert d.data_size(0) == 10
-        assert d.data_size(1) == 20
-
-    def test_data_size_at_exact_boundary(self) -> None:
-        d = VaryingDimension([10, 20, 30], extent=60)
-        assert d.data_size(2) == 30
-
-    def test_data_size_single_element_boundary(self) -> None:
-        d = VaryingDimension([10, 20, 30], extent=31)
-        assert d.data_size(0) == 10
-        assert d.data_size(1) == 20
-        assert d.data_size(2) == 1
-
-    def test_extent_exceeds_sum_rejected(self) -> None:
-        with pytest.raises(ValueError, match="exceeds sum of edges"):
-            VaryingDimension([10, 20], extent=50)
-
-    def test_negative_extent_rejected(self) -> None:
-        with pytest.raises(ValueError, match="must be >= 0"):
-            VaryingDimension([10, 20], extent=-1)
-
-    def test_chunk_spec_boundary_varying(self) -> None:
-        """ChunkGrid with a boundary VaryingDimension produces correct ChunkSpec."""
-        g = ChunkGrid(dimensions=(VaryingDimension([10, 20, 30], extent=50),))
-        spec = g[(2,)]
-        assert spec is not None
-        assert spec.codec_shape == (30,)
-        assert spec.shape == (20,)
-        assert spec.is_boundary is True
-
-    def test_chunk_spec_interior_varying(self) -> None:
-        g = ChunkGrid(dimensions=(VaryingDimension([10, 20, 30], extent=50),))
-        spec = g[(0,)]
-        assert spec is not None
-        assert spec.codec_shape == (10,)
-        assert spec.shape == (10,)
-        assert spec.is_boundary is False
-
-
-class TestMultipleOverflowChunks:
-    """Rectilinear grids where multiple chunks extend past the array extent."""
-
-    def test_multiple_chunks_past_extent(self) -> None:
-        """Edges past extent are structural; nchunks counts active only."""
-        g = ChunkGrid.from_rectilinear([[10, 20, 30, 40]], array_shape=(50,))
-        d = g.dimensions[0]
-        assert d.ngridcells == 4
-        assert d.nchunks == 3
-        assert d.data_size(0) == 10
-        assert d.data_size(1) == 20
-        assert d.data_size(2) == 20
-        assert d.chunk_size(2) == 30
-
-    def test_chunk_spec_past_extent_is_oob(self) -> None:
-        """Chunk entirely past the extent is out of bounds (not active)."""
-        g = ChunkGrid.from_rectilinear([[10, 20, 30, 40]], array_shape=(50,))
-        spec = g[(3,)]
-        assert spec is None
-
-    def test_chunk_spec_partial_overflow(self) -> None:
-        """ChunkSpec for a partially-overflowing chunk clips correctly."""
-        g = ChunkGrid.from_rectilinear([[10, 20, 30, 40]], array_shape=(50,))
-        spec = g[(2,)]
-        assert spec is not None
-        assert spec.shape == (20,)
-        assert spec.codec_shape == (30,)
-        assert spec.is_boundary is True
-        assert spec.slices == (slice(30, 50, 1),)
-
-    def test_chunk_sizes_with_overflow(self) -> None:
-        """chunk_sizes only includes active chunks."""
-        g = ChunkGrid.from_rectilinear([[10, 20, 30, 40]], array_shape=(50,))
-        assert g.chunk_sizes == ((10, 20, 20),)
-
-    def test_multidim_overflow(self) -> None:
-        """Overflow in multiple dimensions simultaneously."""
-        g = ChunkGrid.from_rectilinear([[10, 20, 30], [40, 40, 40]], array_shape=(45, 100))
-        # dim 0: edges sum to 60, extent 45 → chunk 2 partial (45-30=15)
-        # dim 1: edges sum to 120, extent 100 → chunk 2 partial (100-80=20)
-        assert g.chunk_sizes == ((10, 20, 15), (40, 40, 20))
-        spec = g[(2, 2)]
-        assert spec is not None
-        assert spec.shape == (15, 20)
-        assert spec.codec_shape == (30, 40)
-
-    def test_uniform_edges_with_overflow_collapses_to_fixed(self) -> None:
-        """Uniform edges where len == ceildiv(extent, edge) collapse to FixedDimension."""
-        g = ChunkGrid.from_rectilinear([[10, 10, 10, 10]], array_shape=(35,))
-        assert isinstance(g.dimensions[0], FixedDimension)
-        assert g.is_regular
-        assert g.chunk_sizes == ((10, 10, 10, 5),)
-        assert g.dimensions[0].nchunks == 4
-
-    def test_serialization_roundtrip_overflow(self) -> None:
-        """Overflow chunks survive serialization round-trip."""
-        g = ChunkGrid.from_rectilinear([[10, 20, 30, 40]], array_shape=(50,))
-        serialized = serialize_chunk_grid(g, "rectilinear")
-        assert serialized == {
-            "name": "rectilinear",
-            "configuration": {"kind": "inline", "chunk_shapes": [[10, 20, 30, 40]]},
-        }
-        g2 = parse_chunk_grid(serialized, (50,))
-        assert g2.dimensions[0].ngridcells == 4
-        assert g2.dimensions[0].nchunks == 3
-        assert g2.chunk_sizes == ((10, 20, 20),)
-
-    def test_index_to_chunk_near_extent(self) -> None:
-        """Index lookup near and at the extent boundary."""
-        d = VaryingDimension([10, 20, 30, 40], extent=50)
-        assert d.index_to_chunk(29) == 1  # last index in chunk 1
-        assert d.index_to_chunk(30) == 2  # first index in chunk 2
-        assert d.index_to_chunk(49) == 2  # last valid index
-
-
-class TestBoundaryIndexing:
-    """Indexing operations on boundary chunks for both FixedDimension and
-    VaryingDimension, ensuring the isinstance cleanup works correctly."""
-
-    def test_bool_indexer_fixed_boundary(self) -> None:
-        """BoolArrayDimIndexer pads to codec size for FixedDimension boundary."""
-        from zarr.core.indexing import BoolArrayDimIndexer
-
-        # array extent 7, chunk size 5 → 2 chunks, last has data_size=2
-        dim = FixedDimension(size=5, extent=7)
-        mask = np.array([False, False, False, False, False, True, True])
-        indexer = BoolArrayDimIndexer(mask, 7, dim)
-        projections = list(indexer)
-        assert len(projections) == 1
-        p = projections[0]
-        assert p.dim_chunk_ix == 1
-        # boolean selection should be padded to chunk_size (5)
-        sel = p.dim_chunk_sel
-        assert isinstance(sel, np.ndarray)
-        assert sel.shape[0] == 5
-        assert sel[0] is np.True_
-        assert sel[1] is np.True_
-        assert sel[2] is np.False_  # padding
-
-    def test_bool_indexer_varying_boundary(self) -> None:
-        """BoolArrayDimIndexer pads to codec size for VaryingDimension boundary."""
-        from zarr.core.indexing import BoolArrayDimIndexer
-
-        # edges [5, 10], extent=7 -> last chunk has data_size=2, chunk_size=10
-        dim = VaryingDimension([5, 10], extent=7)
-        mask = np.array([False, False, False, False, False, True, True])
-        indexer = BoolArrayDimIndexer(mask, 7, dim)
-        projections = list(indexer)
-        assert len(projections) == 1
-        p = projections[0]
-        assert p.dim_chunk_ix == 1
-        # boolean selection should be padded to chunk_size (10)
-        sel = p.dim_chunk_sel
-        assert isinstance(sel, np.ndarray)
-        assert sel.shape[0] == 10
-        assert sel[0] is np.True_
-        assert sel[1] is np.True_
-        assert sel[2] is np.False_  # padding
-
-    def test_bool_indexer_no_padding_interior(self) -> None:
-        """No padding needed for interior chunks."""
-        from zarr.core.indexing import BoolArrayDimIndexer
-
-        dim = FixedDimension(size=5, extent=10)
-        mask = np.array([True, False, False, False, False, False, False, False, False, False])
-        indexer = BoolArrayDimIndexer(mask, 10, dim)
-        projections = list(indexer)
-        assert len(projections) == 1
-        p = projections[0]
-        assert p.dim_chunk_ix == 0
-        sel = p.dim_chunk_sel
-        assert isinstance(sel, np.ndarray)
-        assert sel.shape[0] == 5  # equals chunk_size, no padding needed
-
-    def test_slice_indexer_varying_boundary(self) -> None:
-        """SliceDimIndexer clips to data_size at boundary for VaryingDimension."""
-        from zarr.core.indexing import SliceDimIndexer
-
-        dim = VaryingDimension([5, 10], extent=7)
-        # select all elements
-        indexer = SliceDimIndexer(slice(None), 7, dim)
-        projections = list(indexer)
-        assert len(projections) == 2
-        # chunk 0: full chunk
-        assert projections[0].dim_chunk_sel == slice(0, 5, 1)
-        # chunk 1: clipped to data_size (2), not chunk_size (10)
-        assert projections[1].dim_chunk_sel == slice(0, 2, 1)
-
-    def test_int_array_indexer_varying_boundary(self) -> None:
-        """IntArrayDimIndexer handles indices near boundary correctly."""
-        from zarr.core.indexing import IntArrayDimIndexer
-
-        dim = VaryingDimension([5, 10], extent=7)
-        indices = np.array([6])  # in chunk 1, offset 5, so chunk-local = 1
-        indexer = IntArrayDimIndexer(indices, 7, dim)
-        projections = list(indexer)
-        assert len(projections) == 1
-        assert projections[0].dim_chunk_ix == 1
-        sel = projections[0].dim_chunk_sel
-        assert isinstance(sel, np.ndarray)
-        np.testing.assert_array_equal(sel, [1])
-
-    def test_slice_indexer_empty_slice_at_boundary(self) -> None:
-        """SliceDimIndexer yields no projections for an empty slice at the dimension boundary."""
-        from zarr.core.indexing import SliceDimIndexer
-
-        dim = FixedDimension(size=2, extent=10)
-        # slice(10, 10) is empty — start equals extent
-        indexer = SliceDimIndexer(slice(10, 10), 10, dim)
-        projections = list(indexer)
-        assert len(projections) == 0
-
-        # also works for VaryingDimension
-        dim_v = VaryingDimension([5, 5], extent=10)
-        indexer_v = SliceDimIndexer(slice(10, 10), 10, dim_v)
-        assert list(indexer_v) == []
-
-    def test_orthogonal_indexer_varying_boundary_advanced(self) -> None:
-        """OrthogonalIndexer with advanced indexing uses per-chunk chunk_size
-        for ix_() conversion, not a precomputed max."""
-        from zarr.core.indexing import OrthogonalIndexer
-
-        # 2D: dim 0 has boundary chunk, dim 1 is regular
-        g = ChunkGrid(
-            dimensions=(
-                VaryingDimension([5, 10], extent=7),
-                FixedDimension(size=4, extent=8),
-            )
-        )
-        indexer = OrthogonalIndexer(
-            selection=(np.array([0, 6]), slice(None)),
-            shape=(7, 8),
-            chunk_grid=g,
-        )
-        projections = list(indexer)
-        # index 0 → chunk 0, index 6 → chunk 1; dim 1 has 2 chunks
-        assert len(projections) == 4
-        coords = {p.chunk_coords for p in projections}
-        assert coords == {(0, 0), (0, 1), (1, 0), (1, 1)}
-
-
-class TestUpdateShapeBoundary:
-    """Resize creates boundary VaryingDimensions with correct extent."""
-
-    def test_shrink_creates_boundary(self) -> None:
-        grid = ChunkGrid.from_rectilinear([[10, 20, 30]], array_shape=(60,))
-        new_grid = grid.update_shape((45,))
-        dim = new_grid.dimensions[0]
-        assert isinstance(dim, VaryingDimension)
-        assert dim.edges == (10, 20, 30)  # last chunk kept (cumulative 60 >= 45)
-        assert dim.extent == 45
-        assert dim.chunk_size(2) == 30  # codec buffer
-        assert dim.data_size(2) == 15  # clipped: 45 - 30 = 15
-
-    def test_shrink_to_exact_boundary(self) -> None:
-        grid = ChunkGrid.from_rectilinear([[10, 20, 30]], array_shape=(60,))
-        new_grid = grid.update_shape((30,))
-        dim = new_grid.dimensions[0]
-        assert isinstance(dim, VaryingDimension)
-        assert dim.edges == (10, 20, 30)  # all edges preserved
-        assert dim.nchunks == 2  # only first two are active (10+20=30 >= 30)
-        assert dim.ngridcells == 3
-        assert dim.extent == 30
-        assert dim.data_size(1) == 20  # no clipping needed
-
-    def test_shrink_chunk_spec(self) -> None:
-        """After shrink, ChunkSpec reflects boundary correctly."""
-        grid = ChunkGrid.from_rectilinear([[10, 20, 30]], array_shape=(60,))
-        new_grid = grid.update_shape((45,))
-        spec = new_grid[(2,)]
-        assert spec is not None
-        assert spec.codec_shape == (30,)
-        assert spec.shape == (15,)
-        assert spec.is_boundary is True
-
-    def test_parse_chunk_grid_rebinds_extent(self) -> None:
-        """parse_chunk_grid re-binds VaryingDimension extent to array shape."""
-        g = ChunkGrid.from_rectilinear([[10, 20, 30]], array_shape=(60,))
-        # sum(edges)=60, array_shape=50 → re-bind extent
-        g2 = parse_chunk_grid(g, (50,))
-        dim = g2.dimensions[0]
-        assert isinstance(dim, VaryingDimension)
-        assert dim.extent == 50
-        assert dim.data_size(2) == 20  # 50 - 30 = 20
-
-
-class TestNchunksWorksForRectilinear:
-    def test_nchunks_returns_correct_count(self) -> None:
-        """nchunks should work for rectilinear arrays."""
-        store = MemoryStore()
-        a = zarr.create_array(store, shape=(30,), chunks=[[10, 20]], dtype="int32")
-        assert a.nchunks == 2
-
-    def test_nchunks_2d_rectilinear(self) -> None:
-        store = MemoryStore()
-        a = zarr.create_array(store, shape=(30, 40), chunks=[[10, 20], [15, 25]], dtype="int32")
-        assert a.nchunks == 4  # 2 chunks x 2 chunks
-
-
-class TestIterChunkRegionsWorksForRectilinear:
-    def test_iter_chunk_regions_rectilinear(self) -> None:
-        """_iter_chunk_regions should work for rectilinear arrays."""
-        from zarr.core.array import _iter_chunk_regions
-
-        store = MemoryStore()
-        a = zarr.create_array(store, shape=(30,), chunks=[[10, 20]], dtype="int32")
-        regions = list(_iter_chunk_regions(a))
-        assert len(regions) == 2
-        assert regions[0] == (slice(0, 10, 1),)
-        assert regions[1] == (slice(10, 30, 1),)


### PR DESCRIPTION
The rectilinear chunk grid spec allows bare integers per dimension (meaning
"regular step size"), distinct from explicit single-element edge lists. This
commit widens `RectilinearChunkGrid.chunk_shapes` to `tuple[int | tuple[int, ...], ...]`
so bare ints are preserved for faithful JSON round-tripping.

Additionally:
- unifies `_validate_chunk_shapes` to handle both regular and rectilinear validation;
  `_parse_chunk_shape` now delegates to it
- adds `from_sizes` method to `ChunkGrid`, accepting `int | Sequence[int]` per dimension
- removes `from_regular` and `from_rectilinear` methods from `ChunkGrid`
- removes `parse_chunk_grid` from `chunk_grids.py` (JSON → ChunkGrid shortcut that
  bypassed the metadata layer)
- removes `serialize_chunk_grid`, `_infer_chunk_grid_name`, and serialization helpers
  from `chunk_grids.py` (ChunkGrid never needs to be serialized; metadata DTOs handle it)
- renames `parse_chunk_grid` in `v3.py` to `parse_chunk_grid_metadata` to disambiguate
- moves the rectilinear feature flag to `RectilinearChunkGrid.__post_init__`
- simplifies sharding codec validation into a single divisibility check for both
  regular and rectilinear grids
- updates `validate_rectilinear_edges` to skip bare-int dimensions
- refactors chunk grid tests to functional style with parametrization
- adds docstrings to all test functions

There are a LOT of changes in here, feel free to pick out individual files or ask me to break it into pieces.